### PR TITLE
Nullable reference types enabled

### DIFF
--- a/FrEee.Tests/FrEee.Tests.csproj
+++ b/FrEee.Tests/FrEee.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/FrEee.WinForms/FrEee.WinForms.csproj
+++ b/FrEee.WinForms/FrEee.WinForms.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <UseWindowsForms>true</UseWindowsForms>
         <Product>FrEee</Product>
         <Company />

--- a/FrEee/FrEee.csproj
+++ b/FrEee/FrEee.csproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>FrEee.Core</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DocumentationFile>bin\Debug\FrEee.Core.xml</DocumentationFile>

--- a/FrEee/FrEee.csproj
+++ b/FrEee/FrEee.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>FrEee.Core</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DocumentationFile>bin\Debug\FrEee.Core.xml</DocumentationFile>

--- a/FrEee/FrEee.csproj
+++ b/FrEee/FrEee.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <OutputType>Library</OutputType>
     <AssemblyName>FrEee.Core</AssemblyName>

--- a/FrEee/FrEee.csproj
+++ b/FrEee/FrEee.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <LangVersion>9.0</LangVersion>
     <OutputType>Library</OutputType>
     <AssemblyName>FrEee.Core</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/FrEee/Game/Enumerations/AbilityTargets.cs
+++ b/FrEee/Game/Enumerations/AbilityTargets.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Utility;
+using FrEee.Utility;
 using System;
+
+#nullable enable
 
 namespace FrEee.Game.Enumerations
 {

--- a/FrEee/Game/Enumerations/AbilityValueRule.cs
+++ b/FrEee/Game/Enumerations/AbilityValueRule.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Utility;
+using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Enumerations
 {

--- a/FrEee/Game/Enumerations/AllianceLevel.cs
+++ b/FrEee/Game/Enumerations/AllianceLevel.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Utility;
+using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Enumerations
 {

--- a/FrEee/Game/Enumerations/AllowedTrades.cs
+++ b/FrEee/Game/Enumerations/AllowedTrades.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Utility;
+using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Enumerations
 {

--- a/FrEee/Game/Enumerations/Conditions.cs
+++ b/FrEee/Game/Enumerations/Conditions.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Game.Enumerations
+#nullable enable
+
+namespace FrEee.Game.Enumerations
 {
 	/// <summary>
 	/// Planetary conditions.

--- a/FrEee/Game/Enumerations/EmpirePlacement.cs
+++ b/FrEee/Game/Enumerations/EmpirePlacement.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Utility;
+using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Enumerations
 {

--- a/FrEee/Game/Enumerations/EventMessageTarget.cs
+++ b/FrEee/Game/Enumerations/EventMessageTarget.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Game.Enumerations
+#nullable enable
+
+namespace FrEee.Game.Enumerations
 {
 	/// <summary>
 	/// Determines who will receive a message when an event occurs.

--- a/FrEee/Game/Enumerations/EventSeverity.cs
+++ b/FrEee/Game/Enumerations/EventSeverity.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Game.Enumerations
+#nullable enable
+
+namespace FrEee.Game.Enumerations
 {
 	/// <summary>
 	/// The severity of a random event.

--- a/FrEee/Game/Enumerations/Mood.cs
+++ b/FrEee/Game/Enumerations/Mood.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Game.Enumerations
+#nullable enable
+
+namespace FrEee.Game.Enumerations
 {
 	/// <summary>
 	/// Population mood.

--- a/FrEee/Game/Enumerations/Relations.cs
+++ b/FrEee/Game/Enumerations/Relations.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Game.Enumerations
+#nullable enable
+
+namespace FrEee.Game.Enumerations
 {
 	/// <summary>
 	/// Diplomatic relations from one empire to another.

--- a/FrEee/Game/Enumerations/ScoreDisplay.cs
+++ b/FrEee/Game/Enumerations/ScoreDisplay.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Utility;
+using FrEee.Utility;
 using System;
+
+#nullable enable
 
 namespace FrEee.Game.Enumerations
 {

--- a/FrEee/Game/Enumerations/SharingPriority.cs
+++ b/FrEee/Game/Enumerations/SharingPriority.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Game.Enumerations
+#nullable enable
+
+namespace FrEee.Game.Enumerations
 {
 	/// <summary>
 	/// Priority for sharing of abilities.

--- a/FrEee/Game/Enumerations/StartingTechnologyLevel.cs
+++ b/FrEee/Game/Enumerations/StartingTechnologyLevel.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Game.Enumerations
+#nullable enable
+
+namespace FrEee.Game.Enumerations
 {
 	public enum StartingTechnologyLevel
 	{

--- a/FrEee/Game/Enumerations/StellarSize.cs
+++ b/FrEee/Game/Enumerations/StellarSize.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace FrEee.Game.Enumerations
 {
 	/// <summary>

--- a/FrEee/Game/Enumerations/TechnologyCost.cs
+++ b/FrEee/Game/Enumerations/TechnologyCost.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Game.Enumerations
+#nullable enable
+
+namespace FrEee.Game.Enumerations
 {
 	/// <summary>
 	/// Cost to research technology.

--- a/FrEee/Game/Enumerations/VehicleTypes.cs
+++ b/FrEee/Game/Enumerations/VehicleTypes.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Enumerations
 {

--- a/FrEee/Game/Enumerations/Visibility.cs
+++ b/FrEee/Game/Enumerations/Visibility.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace FrEee.Game.Enumerations
 {
 	/// <summary>

--- a/FrEee/Game/Enumerations/WeaponTargets.cs
+++ b/FrEee/Game/Enumerations/WeaponTargets.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Utility;
+using FrEee.Utility;
 using System;
+
+#nullable enable
 
 namespace FrEee.Game.Enumerations
 {

--- a/FrEee/Game/Enumerations/WeaponTypes.cs
+++ b/FrEee/Game/Enumerations/WeaponTypes.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Enumerations
 {

--- a/FrEee/Game/Interfaces/ICommand.cs
+++ b/FrEee/Game/Interfaces/ICommand.cs
@@ -23,7 +23,7 @@ namespace FrEee.Game.Interfaces
 		/// <summary>
 		/// Any new (from the client) objects referred to by this command.
 		/// </summary>
-		IEnumerable<IReferrable> NewReferrables { get; }
+		IEnumerable<IReferrable?> NewReferrables { get; }
 
 		/// <summary>
 		/// Executes the command.

--- a/FrEee/Game/Interfaces/ICommand.cs
+++ b/FrEee/Game/Interfaces/ICommand.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Game.Objects.Civilization;
+using FrEee.Game.Objects.Civilization;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Interfaces
 {
@@ -9,14 +11,14 @@ namespace FrEee.Game.Interfaces
 	/// </summary>
 	public interface ICommand : IPromotable
 	{
-		IReferrable Executor { get; }
+		IReferrable? Executor { get; }
 
-		long ExecutorID { get; }
+		long? ExecutorID { get; }
 
 		/// <summary>
 		/// The empire issuing the command.
 		/// </summary>
-		Empire Issuer { get; }
+		Empire? Issuer { get; }
 
 		/// <summary>
 		/// Any new (from the client) objects referred to by this command.
@@ -32,11 +34,11 @@ namespace FrEee.Game.Interfaces
 	/// <summary>
 	/// A command to some object.
 	/// </summary>
-	public interface ICommand<T> : ICommand where T : IReferrable
+	public interface ICommand<T> : ICommand where T : class, IReferrable
 	{
 		/// <summary>
 		/// The object whose queue is being manipulated.
 		/// </summary>
-		new T Executor { get; set; }
+		new T? Executor { get; set; }
 	}
 }

--- a/FrEee/Game/Interfaces/IDamageable.cs
+++ b/FrEee/Game/Interfaces/IDamageable.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Objects.Combat;
+using FrEee.Game.Objects.Combat;
 using FrEee.Modding;
 using FrEee.Utility;
 
@@ -71,7 +71,7 @@ namespace FrEee.Game.Interfaces
 		/// Takes damage.
 		/// </summary>
 		/// <returns>Leftover damage.</returns>
-		int TakeDamage(Hit hit, PRNG dice = null);
+		int TakeDamage(Hit hit, PRNG? dice = null);
 	}
 
 	public interface IDamageableReferrable : IDamageable, IReferrable { }

--- a/FrEee/Game/Interfaces/IDamageable.cs
+++ b/FrEee/Game/Interfaces/IDamageable.cs
@@ -71,7 +71,7 @@ namespace FrEee.Game.Interfaces
 		/// Takes damage.
 		/// </summary>
 		/// <returns>Leftover damage.</returns>
-		int TakeDamage(Hit hit, PRNG? dice = null);
+		int TakeDamage(Hit hit, PRNG dice = null);
 	}
 
 	public interface IDamageableReferrable : IDamageable, IReferrable { }

--- a/FrEee/Game/Interfaces/IDesign.cs
+++ b/FrEee/Game/Interfaces/IDesign.cs
@@ -122,7 +122,7 @@ namespace FrEee.Game.Interfaces
 		/// </summary>
 		IEnumerable<string> Warnings { get; }
 
-		void AddComponent(ComponentTemplate ct, Mount? m = null);
+		void AddComponent(ComponentTemplate ct, Mount m = null);
 
 		/// <summary>
 		/// Creates an order to build this design.

--- a/FrEee/Game/Interfaces/IDesign.cs
+++ b/FrEee/Game/Interfaces/IDesign.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Technology;
 using FrEee.Modding.Templates;
@@ -122,7 +122,7 @@ namespace FrEee.Game.Interfaces
 		/// </summary>
 		IEnumerable<string> Warnings { get; }
 
-		void AddComponent(ComponentTemplate ct, Mount m = null);
+		void AddComponent(ComponentTemplate ct, Mount? m = null);
 
 		/// <summary>
 		/// Creates an order to build this design.

--- a/FrEee/Game/Interfaces/IOwnable.cs
+++ b/FrEee/Game/Interfaces/IOwnable.cs
@@ -9,7 +9,7 @@ namespace FrEee.Game.Interfaces
 	public interface IOwnable
 	{
 		[DoNotCopy]
-		Empire? Owner { get; }
+		Empire Owner { get; }
 	}
 
 	/// <summary>

--- a/FrEee/Game/Interfaces/IOwnable.cs
+++ b/FrEee/Game/Interfaces/IOwnable.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Objects.Civilization;
+using FrEee.Game.Objects.Civilization;
 using FrEee.Utility;
 
 namespace FrEee.Game.Interfaces
@@ -9,7 +9,7 @@ namespace FrEee.Game.Interfaces
 	public interface IOwnable
 	{
 		[DoNotCopy]
-		Empire Owner { get; }
+		Empire? Owner { get; }
 	}
 
 	/// <summary>

--- a/FrEee/Game/Interfaces/IPromotable.cs
+++ b/FrEee/Game/Interfaces/IPromotable.cs
@@ -12,6 +12,6 @@ namespace FrEee.Game.Interfaces
 		/// </summary>
 		/// <param name="idmap"></param>
 		/// <param name="done">Any promoted objects that are already done replacing IDs.</param>
-		void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null);
+		void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null);
 	}
 }

--- a/FrEee/Game/Interfaces/IPromotable.cs
+++ b/FrEee/Game/Interfaces/IPromotable.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace FrEee.Game.Interfaces
 {
@@ -12,6 +12,6 @@ namespace FrEee.Game.Interfaces
 		/// </summary>
 		/// <param name="idmap"></param>
 		/// <param name="done">Any promoted objects that are already done replacing IDs.</param>
-		void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null);
+		void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null);
 	}
 }

--- a/FrEee/Game/Interfaces/IReference.cs
+++ b/FrEee/Game/Interfaces/IReference.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
+
+#nullable enable
 
 namespace FrEee.Game.Interfaces
 {
@@ -12,7 +14,7 @@ namespace FrEee.Game.Interfaces
 	public interface IReference<out TValue> : IPromotable
 	{
 		bool HasValue { get; }
-		TValue Value { get; }
+		TValue? Value { get; }
 	}
 
 	/// <summary>
@@ -38,10 +40,10 @@ namespace FrEee.Game.Interfaces
 		protected ReferenceException(SerializationInfo info, StreamingContext ctx)
 					: base(info, ctx)
 		{
-			ID = (TID)info.GetValue("ID", typeof(TID));
+			ID = (TID?)info.GetValue("ID", typeof(TID));
 		}
 
-		public TID ID { get; private set; }
+		public TID? ID { get; private set; }
 
 		public Type Type { get { return typeof(TValue); } }
 

--- a/FrEee/Game/Objects/AI/AI.cs
+++ b/FrEee/Game/Objects/AI/AI.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Modding;
+using FrEee.Modding;
 using FrEee.Modding.Interfaces;
 using FrEee.Utility;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.AI
 {
@@ -28,14 +30,9 @@ namespace FrEee.Game.Objects.AI
 		/// </summary>
 		public SafeDictionary<string, ICollection<string>> MinisterNames { get; private set; }
 
+		public string? ModID { get; set; }
 
-		public string ModID { get; set; }
-
-		public string Name
-		{
-			get;
-			private set;
-		}
+		public string Name { get; private set; }
 
 		/// <summary>
 		/// The script to run.
@@ -45,7 +42,7 @@ namespace FrEee.Game.Objects.AI
 		/// <summary>
 		/// Parameters from the mod meta templates.
 		/// </summary>
-		public IDictionary<string, object> TemplateParameters { get; set; }
+		public IDictionary<string, object>? TemplateParameters { get; set; }
 
 		/// <summary>
 		/// Allows the AI to act on its domain using information from its context.
@@ -54,7 +51,6 @@ namespace FrEee.Game.Objects.AI
 		/// <param name="context">Contextual data that the AI needs to be aware of.</param>
 		/// <param name="enabledMinisters">The names of any ministers that the player has enabled, keyed by category.</param>
 		public abstract void Act(TDomain domain, TContext context, SafeDictionary<string, ICollection<string>> enabledMinisters);
-		
 
 		public void Dispose()
 		{
@@ -62,12 +58,6 @@ namespace FrEee.Game.Objects.AI
 			IsDisposed = true;
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
-
-
-
+		public override string ToString() => Name;
 	}
 }

--- a/FrEee/Game/Objects/AI/CSAI.cs
+++ b/FrEee/Game/Objects/AI/CSAI.cs
@@ -1,17 +1,18 @@
+using System;
+using System.Collections.Generic;
+
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Space;
 using FrEee.Modding;
 using FrEee.Utility;
+
 using Microsoft.CodeAnalysis.Scripting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.AI
 {
-    [Serializable]
+	[Serializable]
     public class CSAI<TDomain, TContext> : AI<TDomain, TContext> where TDomain : Empire where TContext : Galaxy
     {
         public CSAI(string name, CSScript script, SafeDictionary<string, ICollection<string>> ministerNames) 
@@ -19,7 +20,6 @@ namespace FrEee.Game.Objects.AI
         {
             ScriptRunner = script.CreateScriptObject<Globals, TDomain>(); 
         }
-
 
         /// <summary>
         /// The object that holds a cs script within memory. 
@@ -59,10 +59,10 @@ namespace FrEee.Game.Objects.AI
     /// </summary>
     public class Globals
     {
-        public Empire Domain;
+        public Empire? Domain;
 
-        public Galaxy Context;
+        public Galaxy? Context;
 
-        public SafeDictionary<string, ICollection<string>> EnabledMinisters;
+        public SafeDictionary<string, ICollection<string>>? EnabledMinisters;
     }
 }

--- a/FrEee/Game/Objects/AI/PythonAI.cs
+++ b/FrEee/Game/Objects/AI/PythonAI.cs
@@ -1,14 +1,14 @@
-﻿using FrEee.Modding;
-using FrEee.Utility;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using FrEee.Modding;
+using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.AI
 {
-    [Serializable]
+	[Serializable]
     public class PythonAI<TDomain, TContext> : AI<TDomain, TContext>
     {
         public PythonAI(string name, PythonScript script, SafeDictionary<string, ICollection<string>> ministerNames) : base(name, script, ministerNames)
@@ -17,14 +17,12 @@ namespace FrEee.Game.Objects.AI
 
         public override void Act(TDomain domain, TContext context, SafeDictionary<string, ICollection<string>> EnabledMinisters)
         {
-       
-            var variables = new Dictionary<string, object>();
+            var variables = new Dictionary<string, object?>();
             variables.Add("domain", domain);
-            var readOnlyVariables = new Dictionary<string, object>();
+            var readOnlyVariables = new Dictionary<string, object?>();
             readOnlyVariables.Add("context", context);
             readOnlyVariables.Add("enabledMinisters", EnabledMinisters);
             PythonScriptEngine.RunScript<object>(Script as PythonScript, variables, readOnlyVariables);
-            
         }
     }
 }

--- a/FrEee/Game/Objects/Abilities/Ability.cs
+++ b/FrEee/Game/Objects/Abilities/Ability.cs
@@ -24,7 +24,7 @@ namespace FrEee.Game.Objects.Abilities
 			Values = new List<Formula<string>>();
 		}
 
-		public Ability(IAbilityObject container, AbilityRule rule, string? description = null, params object[] values)
+		public Ability(IAbilityObject container, AbilityRule rule, string description = null, params object[] values)
 		{
 			Container = container;
 			Rule = rule;
@@ -99,9 +99,9 @@ namespace FrEee.Game.Objects.Abilities
 		public string ModID { get; set; }
 
 		// TODO - should abilities even have names?
-		public string? Name => null;
+		public string Name => null;
 
-		public Empire? Owner => (Container as IOwnable)?.Owner;
+		public Empire Owner => (Container as IOwnable)?.Owner;
 
 		/// <summary>
 		/// The ability rule which defines what ability this is.

--- a/FrEee/Game/Objects/Abilities/Ability.cs
+++ b/FrEee/Game/Objects/Abilities/Ability.cs
@@ -24,7 +24,7 @@ namespace FrEee.Game.Objects.Abilities
 			Values = new List<Formula<string>>();
 		}
 
-		public Ability(IAbilityObject container, AbilityRule rule, string description = null, params object[] values)
+		public Ability(IAbilityObject container, AbilityRule rule, string? description = null, params object[] values)
 		{
 			Container = container;
 			Rule = rule;
@@ -92,44 +92,22 @@ namespace FrEee.Game.Objects.Abilities
 			}
 		}
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
-		public bool IsDisposed
-		{
-			get;
-			set;
-		}
+		public bool IsDisposed { get; set; }
 
-		public string ModID
-		{
-			get;
-			set;
-		}
+		public string ModID { get; set; }
 
-		public string Name
-		{
-			get { return null; } // TODO - should abilities even have names?
-		}
+		// TODO - should abilities even have names?
+		public string? Name => null;
 
-		public Empire Owner
-		{
-			get
-			{
-				if (Container is IOwnable)
-					return (Container as IOwnable).Owner;
-				return null;
-			}
-		}
+		public Empire? Owner => (Container as IOwnable)?.Owner;
 
 		/// <summary>
 		/// The ability rule which defines what ability this is.
 		/// </summary>
 		[DoNotCopy]
-		public AbilityRule Rule { get { return rule; } set { rule = value; } }
+		public AbilityRule Rule { get => rule; set => rule = value; }
 
 		/// <summary>
 		/// Parameters from the mod meta templates.
@@ -139,24 +117,12 @@ namespace FrEee.Game.Objects.Abilities
 		/// <summary>
 		/// The first value of the ability. Not all abilities have values, so this might be null!
 		/// </summary>
-		public Formula<string> Value1
-		{
-			get
-			{
-				return Values.ElementAtOrDefault(0);
-			}
-		}
+		public Formula<string> Value1 => Values.ElementAtOrDefault(0);
 
 		/// <summary>
 		/// The second value of the ability. Not all abilities have two values, so this might be null!
 		/// </summary>
-		public Formula<string> Value2
-		{
-			get
-			{
-				return Values.ElementAtOrDefault(1);
-			}
-		}
+		public Formula<string> Value2 => Values.ElementAtOrDefault(1);
 
 		/// <summary>
 		/// Extra data for the ability.
@@ -182,8 +148,8 @@ namespace FrEee.Game.Objects.Abilities
 		{
 			if (IsDisposed)
 				return;
-			if (Container is IAbilityContainer)
-				(Container as IAbilityContainer).Abilities.Remove(this);
+			if (Container is IAbilityContainer abilityContainer)
+				abilityContainer.Abilities.Remove(this);
 			Galaxy.Current.UnassignID(this);
 		}
 

--- a/FrEee/Game/Objects/Abilities/AbilityRule.cs
+++ b/FrEee/Game/Objects/Abilities/AbilityRule.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Abilities
 {
 	/// <summary>
@@ -34,7 +36,7 @@ namespace FrEee.Game.Objects.Abilities
 		/// A default description for abilities which do not provide their own description.
 		/// Can use, e.g. [%Amount1%] to specify the amount in the Value 1 field.
 		/// </summary>
-		public Formula<string> Description { get; set; }
+		public Formula<string>? Description { get; set; }
 
 		/// <summary>
 		/// The rules for stacking abilities after grouping.
@@ -70,25 +72,14 @@ namespace FrEee.Game.Objects.Abilities
 			}
 		}
 
-		public bool IsDisposed
-		{
-			get
-			{
-				// can't be disposed of
-				return false;
-			}
-		}
+		public bool IsDisposed => false; // can't be disposed of
 
-		public string ModID
-		{
-			get;
-			set;
-		}
+		public string? ModID { get; set; }
 
 		/// <summary>
 		/// The name of the ability to which this rule applies.
 		/// </summary>
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
 		/// <summary>
 		/// Valid targets for this ability.
@@ -98,7 +89,7 @@ namespace FrEee.Game.Objects.Abilities
 		/// <summary>
 		/// Parameters from the mod meta templates.
 		/// </summary>
-		public IDictionary<string, object> TemplateParameters { get; set; }
+		public IDictionary<string, object>? TemplateParameters { get; set; }
 
 		/// <summary>
 		/// The rules for grouping and stacking abilities.
@@ -110,20 +101,14 @@ namespace FrEee.Game.Objects.Abilities
 		/// </summary>
 		/// <param name="nameOrAlias">The name or alias.</param>
 		/// <returns>The ability rule, or null if none matches.</returns>
-		public static AbilityRule Find(string nameOrAlias)
-		{
-			return Mod.Current.AbilityRules.Where(r => r.Matches(nameOrAlias)).SingleOrDefault();
-		}
+		public static AbilityRule Find(string nameOrAlias) => Mod.Current.AbilityRules.Where(r => r.Matches(nameOrAlias)).SingleOrDefault();
 
 		/// <summary>
 		/// Can this ability target something?
 		/// </summary>
 		/// <param name="target"></param>
 		/// <returns></returns>
-		public bool CanTarget(AbilityTargets target)
-		{
-			return Targets.HasFlag(target);
-		}
+		public bool CanTarget(AbilityTargets target) => Targets.HasFlag(target);
 
 		public void Dispose()
 		{
@@ -209,13 +194,14 @@ namespace FrEee.Game.Objects.Abilities
 		/// <returns></returns>
 		public bool StartsWith(string prefix)
 		{
+			if (Name is null)
+			{
+				return false;
+			}
 			return Name.StartsWith(prefix) || Aliases.Any(a => a.StartsWith(prefix));
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name ?? string.Empty;
 
 		private ILookup<Ability, Ability> Stack(IEnumerable<Ability> abilities, IAbilityObject stackingTo, bool groupStacking)
 		{

--- a/FrEee/Game/Objects/Abilities/AbilityRule.cs
+++ b/FrEee/Game/Objects/Abilities/AbilityRule.cs
@@ -140,10 +140,10 @@ namespace FrEee.Game.Objects.Abilities
 				if (existingKey == null)
 				{
 					dict[key] = new List<Ability>();
-					dict[key].Add(a);
+					dict[key]!.Add(a);
 				}
 				else
-					dict[existingKey].Add(a);
+					dict[existingKey]!.Add(a);
 			}
 
 			// stack abilities

--- a/FrEee/Game/Objects/Civilization/Aptitude.cs
+++ b/FrEee/Game/Objects/Civilization/Aptitude.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -36,11 +38,11 @@ namespace FrEee.Game.Objects.Civilization
 			}
 		}
 
-		public string AbilityName { get; set; }
+		public string? AbilityName { get; set; }
 
 		public int Cost { get; set; }
 
-		public string Description { get; set; }
+		public string? Description { get; set; }
 
 		public int HighCost { get; set; }
 
@@ -50,7 +52,7 @@ namespace FrEee.Game.Objects.Civilization
 
 		public int MinPercent { get; set; }
 
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
 		public int Threshold { get; set; }
 
@@ -181,9 +183,6 @@ namespace FrEee.Game.Objects.Civilization
 				return 0;
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name ?? string.Empty;
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Cargo.cs
+++ b/FrEee/Game/Objects/Civilization/Cargo.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Combat;
 using FrEee.Modding;
 using FrEee.Utility;
@@ -6,6 +6,8 @@ using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -20,15 +22,9 @@ namespace FrEee.Game.Objects.Civilization
 			Units = new HashSet<IUnit>();
 		}
 
-		public int ArmorHitpoints
-		{
-			get { return Units.Sum(u => u.ArmorHitpoints); }
-		}
+		public int ArmorHitpoints => Units.Sum(u => u.ArmorHitpoints);
 
-		public int HitChance
-		{
-			get { return 1; }
-		}
+		public int HitChance => 1;
 
 		[DoNotSerialize(false)]
 		public int Hitpoints
@@ -44,20 +40,11 @@ namespace FrEee.Game.Objects.Civilization
 			}
 		}
 
-		public int HullHitpoints
-		{
-			get { return Units.Sum(u => u.HullHitpoints) + (int)(Population.Sum(kvp => kvp.Value) * Mod.Current.Settings.PopulationHitpoints); }
-		}
+		public int HullHitpoints => Units.Sum(u => u.HullHitpoints) + (int)(Population.Sum(kvp => kvp.Value) * Mod.Current.Settings.PopulationHitpoints);
 
-		public bool IsDestroyed
-		{
-			get { return Hitpoints <= 0; }
-		}
+		public bool IsDestroyed => Hitpoints <= 0;
 
-		public int MaxArmorHitpoints
-		{
-			get { return Units.Sum(u => u.MaxArmorHitpoints); }
-		}
+		public int MaxArmorHitpoints => Units.Sum(u => u.MaxArmorHitpoints);
 
 		public int MaxHitpoints
 		{
@@ -68,25 +55,13 @@ namespace FrEee.Game.Objects.Civilization
 			}
 		}
 
-		public int MaxHullHitpoints
-		{
-			get { return Units.Sum(u => u.MaxHullHitpoints); }
-		}
+		public int MaxHullHitpoints => Units.Sum(u => u.MaxHullHitpoints);
 
-		public int MaxNormalShields
-		{
-			get { return 0; }
-		}
+		public int MaxNormalShields => 0;
 
-		public int MaxPhasedShields
-		{
-			get { return 0; }
-		}
+		public int MaxPhasedShields => 0;
 
-		public int MaxShieldHitpoints
-		{
-			get { return Units.Sum(u => u.MaxShieldHitpoints); }
-		}
+		public int MaxShieldHitpoints => Units.Sum(u => u.MaxShieldHitpoints);
 
 		[DoNotSerialize(false)]
 		public int NormalShields
@@ -119,10 +94,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// </summary>
 		public SafeDictionary<Race, long> Population { get; set; }
 
-		public int ShieldHitpoints
-		{
-			get { return Units.Sum(u => u.ShieldHitpoints); }
-		}
+		public int ShieldHitpoints => Units.Sum(u => u.ShieldHitpoints);
 
 		/// <summary>
 		/// The amount of space taken by this cargo.
@@ -200,7 +172,7 @@ namespace FrEee.Game.Objects.Civilization
 			Units.Clear();
 		}
 
-		public int TakeDamage(Hit hit, PRNG dice = null)
+		public int TakeDamage(Hit hit, PRNG? dice = null)
 		{
 			int damage = hit.NominalDamage;
 			if (Population.Any() && Units.Any())
@@ -226,7 +198,7 @@ namespace FrEee.Game.Objects.Civilization
 				return damage; // nothing to damage
 		}
 
-		private int TakePopulationDamage(Hit hit, int damage, PRNG dice = null)
+		private int TakePopulationDamage(Hit hit, int damage, PRNG? dice = null)
 		{
 			int inflicted = 0;
 			for (int i = 0; i < damage; i++)
@@ -249,7 +221,7 @@ namespace FrEee.Game.Objects.Civilization
 			return damage - inflicted;
 		}
 
-		private int TakeUnitDamage(Hit hit, int damage, PRNG dice = null)
+		private int TakeUnitDamage(Hit hit, int damage, PRNG? dice = null)
 		{
 			// units with more HP are more likely to get hit first, like with leaky armor
 			var units = Units.Where(u => !u.IsDestroyed).ToDictionary(u => u, u => u.MaxHitpoints);

--- a/FrEee/Game/Objects/Civilization/Cargo.cs
+++ b/FrEee/Game/Objects/Civilization/Cargo.cs
@@ -209,7 +209,7 @@ namespace FrEee.Game.Objects.Civilization
 					break; // no more population
 				double popHPPerPerson = Mod.Current.Settings.PopulationHitpoints;
 				// TODO - don't ceiling the popKilled, just stack it up
-				int popKilled = (int)Math.Ceiling(hit.Shot.DamageType.PopulationDamage.Evaluate(hit.Shot) / popHPPerPerson);
+				int popKilled = (int)Math.Ceiling(hit.Shot?.DamageType.PopulationDamage.Evaluate(hit.Shot) ?? 0 / popHPPerPerson);
 				Population[race] -= popKilled;
 				if (Population[race] < 0)
 					Population[race] = 0;

--- a/FrEee/Game/Objects/Civilization/Cargo.cs
+++ b/FrEee/Game/Objects/Civilization/Cargo.cs
@@ -209,7 +209,7 @@ namespace FrEee.Game.Objects.Civilization
 					break; // no more population
 				double popHPPerPerson = Mod.Current.Settings.PopulationHitpoints;
 				// TODO - don't ceiling the popKilled, just stack it up
-				int popKilled = (int)Math.Ceiling(hit.Shot?.DamageType.PopulationDamage.Evaluate(hit.Shot) ?? 0 / popHPPerPerson);
+				int popKilled = (int)Math.Ceiling((hit.Shot?.DamageType.PopulationDamage.Evaluate(hit.Shot) ?? 0) / popHPPerPerson);
 				Population[race] -= popKilled;
 				if (Population[race] < 0)
 					Population[race] = 0;

--- a/FrEee/Game/Objects/Civilization/CargoDelta.cs
+++ b/FrEee/Game/Objects/Civilization/CargoDelta.cs
@@ -1,10 +1,12 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Modding;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -63,7 +65,7 @@ namespace FrEee.Game.Objects.Civilization
 		public GalaxyReferenceSet<IUnit> Units { get; private set; }
 		public SafeDictionary<VehicleTypes, int?> UnitTypeTonnage { get; private set; }
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();
@@ -91,7 +93,7 @@ namespace FrEee.Game.Objects.Civilization
 			else if (AnyPopulation != 0)
 				items.Add(AnyPopulation.ToUnitString() + " Population of Any Race");
 			foreach (var unit in Units)
-				items.Add(unit.ToString());
+				items.Add(unit.ToString() ?? "null unit");
 			foreach (var kvp in UnitDesignTonnage)
 			{
 				if (kvp.Value == null)

--- a/FrEee/Game/Objects/Civilization/Colony.cs
+++ b/FrEee/Game/Objects/Civilization/Colony.cs
@@ -10,6 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Civilization
 {
 	/// <summary>
@@ -25,10 +27,7 @@ namespace FrEee.Game.Objects.Civilization
 			Cargo = new Cargo();
 		}
 
-		public AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.Planet; }
-		}
+		public AbilityTargets AbilityTarget => AbilityTargets.Planet;
 
 		/// <summary>
 		/// The anger level of each race on this colony.
@@ -50,30 +49,14 @@ namespace FrEee.Game.Objects.Civilization
 		/// </summary>
 		public Cargo Cargo { get; set; }
 
-		public IEnumerable<IAbilityObject> Children
-		{
-			get
-			{
-				return Facilities.Cast<IAbilityObject>().Concat(Cargo.Units.Cast<IAbilityObject>());
-			}
-		}
+		public IEnumerable<IAbilityObject> Children => Facilities.Cast<IAbilityObject>().Concat(Cargo.Units.Cast<IAbilityObject>());
 
 		/// <summary>
 		/// This colony's construction queue.
 		/// </summary>
-		public ConstructionQueue ConstructionQueue
-		{
-			get;
-			set;
-		}
+		public ConstructionQueue? ConstructionQueue { get; set; }
 
-		public Planet Container
-		{
-			get
-			{
-				return Galaxy.Current.FindSpaceObjects<Planet>().SingleOrDefault(p => p.Colony == this);
-			}
-		}
+		public Planet Container => Galaxy.Current.FindSpaceObjects<Planet>().SingleOrDefault(p => p.Colony == this);
 
 		/// <summary>
 		/// The facilities on this colony.
@@ -95,11 +78,7 @@ namespace FrEee.Game.Objects.Civilization
 
 		public bool IsHomeworld { get; set; }
 
-		public bool IsMemory
-		{
-			get;
-			set;
-		}
+		public bool IsMemory { get; set; }
 
 		/// <summary>
 		/// Ratio of population that has the "No Spaceports" ability.
@@ -128,7 +107,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// The empire which owns this colony.
 		/// </summary>
-		public Empire Owner { get; set; }
+		public Empire? Owner { get; set; }
 
 		public IEnumerable<IAbilityObject> Parents
 		{
@@ -143,15 +122,9 @@ namespace FrEee.Game.Objects.Civilization
 		/// </summary>
 		public SafeDictionary<Race, long> Population { get; private set; }
 
-		public ResourceQuantity RemoteMiningIncomePercentages
-		{
-			get { return Owner.PrimaryRace.IncomePercentages; }
-		}
+		public ResourceQuantity? RemoteMiningIncomePercentages => Owner?.PrimaryRace?.IncomePercentages;
 
-		public ResourceQuantity ResourceValue
-		{
-			get { return Container.ResourceValue; }
-		}
+		public ResourceQuantity ResourceValue => Container.ResourceValue;
 
 		[DoNotSerialize(false)]
 		public Sector Sector { get => Container.Sector; set => throw new NotSupportedException("Can't set the sector of a colony."); }
@@ -170,9 +143,9 @@ namespace FrEee.Game.Objects.Civilization
 				foreach (var r in Resource.All)
 				{
 					var aptfactor = 1d;
-					if (r.Aptitude != null)
+					if (r.Aptitude?.Name != null)
 						aptfactor = Population.Sum(kvp => (kvp.Key.Aptitudes[r.Aptitude.Name] / 100d) * (double)kvp.Value / (double)totalpop);
-					var cultfactor = (100 + r.CultureModifier(Owner.Culture)) / 100d;
+					var cultfactor = (100 + r.CultureModifier(Owner?.Culture)) / 100d;
 
 					result += (int)(100 * popfactor * aptfactor * cultfactor * moodfactor) * r;
 				}
@@ -181,7 +154,7 @@ namespace FrEee.Game.Objects.Civilization
 			}
 		}
 
-		public StarSystem StarSystem => Container?.StarSystem;
+		public StarSystem? StarSystem => Container?.StarSystem;
 
 		public double Timestamp { get; set; }
 
@@ -217,10 +190,7 @@ namespace FrEee.Game.Objects.Civilization
 			IsDisposed = true;
 		}
 
-		public bool IsObsoleteMemory(Empire emp)
-		{
-			return Container == null || Container.StarSystem.CheckVisibility(emp) >= Visibility.Visible && Timestamp < Galaxy.Current.Timestamp - 1;
-		}
+		public bool IsObsoleteMemory(Empire emp) => Container == null || Container.StarSystem.CheckVisibility(emp) >= Visibility.Visible && Timestamp < Galaxy.Current.Timestamp - 1;
 
 		public void Redact(Empire emp)
 		{

--- a/FrEee/Game/Objects/Civilization/ConstructionQueue.cs
+++ b/FrEee/Game/Objects/Civilization/ConstructionQueue.cs
@@ -507,7 +507,10 @@ namespace FrEee.Game.Objects.Civilization
 				{
 					double aptmod = 0d;
 					foreach (var ratio in ratios)
-						aptmod += ((ratio.Race.Aptitudes[Aptitude.Construction.Name] / 100d)) * ratio.Ratio;
+					{
+						if (Aptitude.Construction.Name != null)
+							aptmod += ratio.Race.Aptitudes[Aptitude.Construction.Name] / 100d * ratio.Ratio;
+					}
 					rate *= aptmod;
 
 					// apply culture modifier
@@ -516,7 +519,7 @@ namespace FrEee.Game.Objects.Civilization
 			}
 			if (rate == null)
 				rate = new ResourceQuantity();
-			if (Container is IVehicle)
+			if (Container is IVehicle && Aptitude.Construction.Name != null)
 			{
 				// apply aptitude modifier for empire's primary race
 				rate *= Owner?.PrimaryRace?.Aptitudes[Aptitude.Construction.Name] ?? 100 / 100d;

--- a/FrEee/Game/Objects/Civilization/Culture.cs
+++ b/FrEee/Game/Objects/Civilization/Culture.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Modding.Interfaces;
 using FrEee.Utility;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -13,7 +15,7 @@ namespace FrEee.Game.Objects.Civilization
 	public class Culture : IModObject
 	{
 		public int Construction { get; set; }
-		public string Description { get; set; }
+		public string? Description { get; set; }
 		public int GroundCombat { get; set; }
 		public int Happiness { get; set; }
 
@@ -33,20 +35,15 @@ namespace FrEee.Game.Objects.Civilization
 
 		public int Intelligence { get; set; }
 
-		public bool IsDisposed
-		{
-			get
-			{
+		public bool IsDisposed =>
 				// can't be disposed of
-				return false;
-			}
-		}
+				false;
 
 		public int MaintenanceReduction { get; set; }
-		public string ModID { get; set; }
-		public string Name { get; set; }
+		public string? ModID { get; set; }
+		public string? Name { get; set; }
 
-		string INamed.Name { get { return Name; } }
+		string? INamed.Name => Name;
 		public int Production { get; set; }
 
 		public int Repair { get; set; }
@@ -56,7 +53,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// Parameters from the mod meta templates.
 		/// </summary>
-		public IDictionary<string, object> TemplateParameters { get; set; }
+		public IDictionary<string, object>? TemplateParameters { get; set; }
 
 		public int Trade { get; set; }
 
@@ -65,9 +62,6 @@ namespace FrEee.Game.Objects.Civilization
 			// nothing to do
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name ?? string.Empty;
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Diplomacy/AcceptProposalAction.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/AcceptProposalAction.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
@@ -11,22 +13,22 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 	/// <typeparam name="T"></typeparam>
 	public class AcceptProposalAction : Action
 	{
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+		// initialized via property
 		public AcceptProposalAction(Proposal proposal)
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 			: base(proposal.Executor)
 		{
 			Proposal = proposal;
 		}
 
-		public override string Description
-		{
-			get { return "Reject " + Proposal; }
-		}
+		public override string Description => $"Reject {Proposal}";
 
 		/// <summary>
 		/// The proposal in question.
 		/// </summary>
 		[DoNotSerialize]
-		public Proposal Proposal { get { return proposal; } set { proposal = value; } }
+		public Proposal Proposal { get => proposal; set => proposal = value; }
 
 		private GalaxyReference<Proposal> proposal { get; set; }
 
@@ -41,10 +43,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 			}
 		}
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
-			if (done == null)
-				done = new HashSet<IPromotable>();
+			done ??= new HashSet<IPromotable>();
 			if (!done.Contains(this))
 			{
 				done.Add(this);

--- a/FrEee/Game/Objects/Civilization/Diplomacy/AcceptProposalAction.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/AcceptProposalAction.cs
@@ -35,10 +35,10 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		public override void Execute()
 		{
 			if (Proposal.IsResolved)
-				Executor.Log.Add(Target.CreateLogMessage("The proposal \"" + Proposal + "\" has already been resolved and cannot be accepted now.", LogMessages.LogMessageType.Error));
+				Executor?.Log.Add(Target.CreateLogMessage("The proposal \"" + Proposal + "\" has already been resolved and cannot be accepted now.", LogMessages.LogMessageType.Error));
 			else
 			{
-				Target.Log.Add(Executor.CreateLogMessage("The " + Executor + " has accepted our proposal (" + Proposal + ").", LogMessages.LogMessageType.Generic));
+				Target?.Log.Add(Executor.CreateLogMessage("The " + Executor + " has accepted our proposal (" + Proposal + ").", LogMessages.LogMessageType.Generic));
 				Proposal.Execute();
 			}
 		}

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Action.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Action.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Game.Objects.Commands;
+using FrEee.Game.Objects.Commands;
 using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
@@ -8,7 +10,10 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 	/// </summary>
 	public abstract class Action : Command<Empire>
 	{
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+		// initialized via property
 		protected Action(Empire target)
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 			: base(Empire.Current)
 		{
 			Target = target;
@@ -20,7 +25,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// The empire that is the target of this action.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Target { get { return target; } set { target = value; } }
+		public Empire Target { get => target; set => target = value; }
 
 		private GalaxyReference<Empire> target { get; set; }
 	}

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Action.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Action.cs
@@ -12,7 +12,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 	{
 #pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 		// initialized via property
-		protected Action(Empire target)
+		protected Action(Empire? target)
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 			: base(Empire.Current)
 		{
@@ -25,8 +25,8 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// The empire that is the target of this action.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Target { get => target; set => target = value; }
+		public Empire? Target { get => target; set => target = value; }
 
-		private GalaxyReference<Empire> target { get; set; }
+		private GalaxyReference<Empire?> target { get; set; }
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Diplomacy/ActionMessage.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/ActionMessage.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
@@ -19,27 +21,15 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// <summary>
 		/// The action in question.
 		/// </summary>
-		public Action Action { get; set; }
+		public Action? Action { get; set; }
 
-		public override IEnumerable<string> IconPaths
-		{
-			get
-			{
-				return Owner.IconPaths;
-			}
-		}
+		public override IEnumerable<string> IconPaths => Owner.IconPaths;
 
-		public override IEnumerable<string> PortraitPaths
-		{
-			get
-			{
-				return Owner.PortraitPaths;
-			}
-		}
+		public override IEnumerable<string> PortraitPaths => Owner.PortraitPaths;
 
 		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
 		{
-			Action.ReplaceClientIDs(idmap);
+			Action?.ReplaceClientIDs(idmap);
 		}
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Diplomacy/ActionMessage.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/ActionMessage.cs
@@ -23,11 +23,11 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// </summary>
 		public Action? Action { get; set; }
 
-		public override IEnumerable<string> IconPaths => Owner.IconPaths;
+		public override IEnumerable<string>? IconPaths => Owner?.IconPaths;
 
-		public override IEnumerable<string> PortraitPaths => Owner.PortraitPaths;
+		public override IEnumerable<string>? PortraitPaths => Owner?.PortraitPaths;
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			Action?.ReplaceClientIDs(idmap);
 		}

--- a/FrEee/Game/Objects/Civilization/Diplomacy/BreakTreatyAction.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/BreakTreatyAction.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
@@ -12,10 +14,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		{
 		}
 
-		public override string Description
-		{
-			get { return "Break Treaty"; }
-		}
+		public override string Description => "Break Treaty";
 
 		public override void Execute()
 		{

--- a/FrEee/Game/Objects/Civilization/Diplomacy/BreakTreatyAction.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/BreakTreatyAction.cs
@@ -18,14 +18,17 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 
 		public override void Execute()
 		{
+			if (Executor is null)
+				return;
+
 			foreach (var clause in Executor.GetTreaty(Target))
 				clause.Dispose();
 
 			Executor.Log.Add(Target.CreateLogMessage("We have broken our treaty with the " + Target + ".", LogMessages.LogMessageType.Generic));
-			Target.Log.Add(Executor.CreateLogMessage("The " + Target + " has broken its treaty with us.", LogMessages.LogMessageType.Generic));
+			Target?.Log.Add(Executor.CreateLogMessage("The " + Target + " has broken its treaty with us.", LogMessages.LogMessageType.Generic));
 
 			Executor.TriggerHappinessChange(hm => hm.TreatyNone);
-			Target.TriggerHappinessChange(hm => hm.TreatyNone);
+			Target?.TriggerHappinessChange(hm => hm.TreatyNone);
 		}
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/AllianceClause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/AllianceClause.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Objects.Commands;
 using FrEee.Utility.Extensions;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 {
@@ -22,13 +24,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		/// </summary>
 		public AllianceLevel AllianceLevel { get; set; }
 
-		public override string BriefDescription
-		{
-			get
-			{
-				return AllianceLevel.ToSpacedString();
-			}
-		}
+		public override string BriefDescription => AllianceLevel.ToSpacedString();
 
 		public override string FullDescription
 		{

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/AllianceClause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/AllianceClause.cs
@@ -72,8 +72,11 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 			}
 		}
 
-		private void DeclareWar(Empire emp)
+		private void DeclareWar(Empire? emp)
 		{
+			if (emp is null)
+				return;
+
 			// send declaration of war to the empire in question
 			// note that you might not have even encountered them yet, but meh...
 			var response = new ActionMessage(emp);
@@ -81,8 +84,8 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 			response.Text = "Our allies have forced our hand. We must declare war!";
 			response.Action = new DeclareWarAction(emp);
 			var cmd = new SendMessageCommand(response);
-			Empire.Current.Commands.Add(cmd);
-			Empire.Current.TriggerHappinessChange(hm => hm.TreatyWar);
+			Empire.Current?.Commands.Add(cmd);
+			Empire.Current?.TriggerHappinessChange(hm => hm.TreatyWar);
 			emp.TriggerHappinessChange(hm => hm.TreatyWar);
 		}
 	}

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/Clause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/Clause.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Space;
 using FrEee.Utility;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 {
@@ -11,7 +13,10 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 	/// </summary>
 	public abstract class Clause : IOwnable, IFoggable, IPromotable, IReferrable
 	{
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+		// initialized via property
 		protected Clause(Empire giver, Empire receiver)
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 		{
 			Giver = giver;
 			Receiver = receiver;
@@ -31,13 +36,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		/// The empire that is offering something in this clause.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Giver { get { return giver; } set { giver = value; } }
+		public Empire Giver { get => giver; set => giver = value; }
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
 		public bool IsDisposed { get; set; }
 
@@ -46,28 +47,17 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		/// </summary>
 		public bool IsInEffect { get; set; }
 
-		public bool IsMemory
-		{
-			get;
-			set;
-		}
+		public bool IsMemory { get; set; }
 
-		public Empire Owner
-		{
-			get { return Receiver; }
-		}
+		public Empire Owner => Receiver;
 
 		/// <summary>
 		/// The empire that is receiving a benefit from this clause.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Receiver { get { return receiver; } set { receiver = value; } }
+		public Empire Receiver { get => receiver; set => receiver = value; }
 
-		public double Timestamp
-		{
-			get;
-			set;
-		}
+		public double Timestamp { get; set; }
 
 		private GalaxyReference<Empire> giver { get; set; }
 		private GalaxyReference<Empire> receiver { get; set; }
@@ -90,10 +80,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 			IsInEffect = false;
 		}
 
-		public bool IsObsoleteMemory(Empire emp)
-		{
-			return false;
-		}
+		public bool IsObsoleteMemory(Empire emp) => false;
 
 		/// <summary>
 		/// Performs any per-turn action for this treaty clause, if applicable.
@@ -106,14 +93,11 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 				Dispose();
 		}
 
-		public virtual void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public virtual void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			// nothing to do here...
 		}
 
-		public override string ToString()
-		{
-			return BriefDescription;
-		}
+		public override string ToString() => BriefDescription;
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/CooperativeResearchClause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/CooperativeResearchClause.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Modding;
+using FrEee.Modding;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System.Linq;
 using Tech = FrEee.Game.Objects.Technology.Technology;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 {
@@ -18,18 +20,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		{
 		}
 
-		public override string BriefDescription
-		{
-			get { return "Cooperative Research"; }
-		}
+		public override string BriefDescription => "Cooperative Research";
 
-		public override string FullDescription
-		{
-			get
-			{
-				return Receiver.WeOrName() + " has a " + Mod.Current.Settings.CooperativeResearchBreakthroughChance + "% chance of achieving a breakthrough each turn in any technology that " + Giver.WeOrName(false) + " " + (Giver == Empire.Current ? "are" : "is") + " more advanced in, provided " + Receiver.WeOrName() + " meet" + (Receiver == Empire.Current ? "" : "s") + " the prerequisites.";
-			}
-		}
+		public override string FullDescription => $"{Receiver.WeOrName()} has a {Mod.Current.Settings.CooperativeResearchBreakthroughChance}% chance of achieving a breakthrough each turn in any technology that {Giver.WeOrName(false)} {(Giver == Empire.Current ? "are" : "is")} more advanced in, provided {Receiver.WeOrName()} meet{(Receiver == Empire.Current ? "" : "s")} the prerequisites.";
 
 		public override void PerformAction()
 		{
@@ -60,7 +53,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 							hasProgress.Value = 0;
 						}
 						else
-							hasProgress.Value = giveProgress.Value;
+							hasProgress.Value = giveProgress?.Value ?? 0;
 						Giver.Log.Add(Receiver.CreateLogMessage("The " + Receiver + " has achieved a breakthrough in " + tech + " due to our cooperative research treaty.", LogMessages.LogMessageType.Generic));
 						Receiver.Log.Add(tech.CreateLogMessage("We have achieved a breakthrough in " + tech + " due to our cooperative research treaty with the " + Giver + ".", LogMessages.LogMessageType.ResearchComplete));
 					}

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/FreeTradeClause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/FreeTradeClause.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Modding;
+using FrEee.Modding;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System;
@@ -23,36 +23,19 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		/// </summary>
 		public int Amount { get; set; }
 
-		public override string BriefDescription
-		{
-			get { return "Free Trade (" + Resource + ")"; }
-		}
+		public override string BriefDescription => $"Free Trade ({Resource})";
 
-		public override string FullDescription
-		{
-			get
-			{
-				return Receiver.WeOrName() + " will receive income equal to " + TradePercentage + "% of " + Giver.UsOrName().Possessive() + " gross " + Resource.Name.ToLower() + " income (will increase to " + Mod.Current.Settings.MaxTradePercent + "% over " + Math.Ceiling(Mod.Current.Settings.MaxTradePercent - TradePercentage) / Mod.Current.Settings.TradePercentPerTurn + " turns).";
-			}
-		}
+		public override string FullDescription => $"{Receiver.WeOrName()} will receive income equal to {TradePercentage}% of {Giver.UsOrName().Possessive()} gross {Resource.Name.ToLower()} income (will increase to {Mod.Current.Settings.MaxTradePercent}% over {Math.Ceiling(Mod.Current.Settings.MaxTradePercent - TradePercentage) / Mod.Current.Settings.TradePercentPerTurn} turns).";
 
 		/// <summary>
 		/// The resource being traded.
 		/// </summary>
-		public Resource Resource
-		{
-			get;
-			set;
-		}
+		public Resource Resource { get; set; }
 
 		/// <summary>
 		/// The percentage of the giver's income that will be traded.
 		/// </summary>
-		public double TradePercentage
-		{
-			get;
-			set;
-		}
+		public double TradePercentage { get; set; }
 
 		public override void PerformAction()
 		{

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/ShareAbilityClause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/ShareAbilityClause.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Objects.Abilities;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 {
@@ -21,18 +23,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		/// </summary>
 		public AbilityRule AbilityRule { get; set; }
 
-		public override string BriefDescription
-		{
-			get { return "Share Ability (" + AbilityRule.Name + ") - " + Priority + " Priority"; }
-		}
+		public override string BriefDescription => $"Share Ability ({AbilityRule.Name}) - {Priority} Priority";
 
-		public override string FullDescription
-		{
-			get
-			{
-				return Giver.WeOrName() + " will share the " + AbilityRule.Name + " ability with " + Receiver.UsOrName() + " at " + Priority.ToString().ToLower() + " priority.";
-			}
-		}
+		public override string FullDescription => $"{Giver.WeOrName()} will share the {AbilityRule.Name} ability with {Receiver.UsOrName()} at {Priority.ToString().ToLower()} priority.";
 
 		/// <summary>
 		/// The priority of sharing with this empire.

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/ShareCombatLogsClause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/ShareCombatLogsClause.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Objects.Combat;
+using FrEee.Game.Objects.Combat;
 using FrEee.Game.Objects.LogMessages;
 using FrEee.Utility.Extensions;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 {
@@ -15,18 +17,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		{
 		}
 
-		public override string BriefDescription
-		{
-			get { return "Share Combat Logs"; }
-		}
+		public override string BriefDescription => "Share Combat Logs";
 
-		public override string FullDescription
-		{
-			get
-			{
-				return Giver.WeOrName() + " will share all combat logs with " + Receiver.UsOrName();
-			}
-		}
+		public override string FullDescription => $"{Giver.WeOrName()} will share all combat logs with {Receiver.UsOrName()}";
 
 		public override void PerformAction()
 		{

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/ShareDesignsClause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/ShareDesignsClause.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 {
@@ -12,18 +14,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		{
 		}
 
-		public override string BriefDescription
-		{
-			get { return "Share Designs"; }
-		}
+		public override string BriefDescription => "Share Designs";
 
-		public override string FullDescription
-		{
-			get
-			{
-				return Giver.WeOrName() + " will share all known vehicle designs with " + Receiver.UsOrName();
-			}
-		}
+		public override string FullDescription => $"{Giver.WeOrName()} will share all known vehicle designs with {Receiver.UsOrName()}";
 
 		public override void PerformAction()
 		{

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/ShareVisionClause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/ShareVisionClause.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 {
@@ -12,18 +14,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		{
 		}
 
-		public override string BriefDescription
-		{
-			get { return "Share Vision"; }
-		}
+		public override string BriefDescription => "Share Vision";
 
-		public override string FullDescription
-		{
-			get
-			{
-				return Giver.WeOrName() + " will share all vision memory with " + Receiver.UsOrName();
-			}
-		}
+		public override string FullDescription => $"{Giver.WeOrName()} will share all vision memory with {Receiver.UsOrName()}";
 
 		public override void PerformAction()
 		{

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/TributeClause.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Clauses/TributeClause.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Utility;
+using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 {
@@ -19,18 +21,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 			IsPercentage = isPercentage;
 		}
 
-		public override string BriefDescription
-		{
-			get
-			{
-				string qty;
-				if (IsPercentage)
-					qty = Quantity + "%";
-				else
-					qty = Quantity.ToUnitString(true);
-				return "Tribute (" + Resource + ") - " + qty;
-			}
-		}
+		public override string BriefDescription => $"Tribute ({Resource}) - {(IsPercentage ? Quantity + "%" : Quantity.ToUnitString(true))}";
 
 		/// <summary>
 		/// The amount of tribute owed.
@@ -45,16 +36,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 			}
 		}
 
-		public override string FullDescription
-		{
-			get
-			{
-				if (IsPercentage)
-					return Giver.WeOrName() + " will pay " + Receiver.UsOrName() + " a tribute of " + Quantity + "% of " + Giver.WeOrName(false).Possessive() + " gross " + Resource.Name.ToLower() + " income.";
-				else
-					return Giver.WeOrName() + " will pay " + Receiver.UsOrName() + " a tribute of " + Quantity.ToUnitString(true) + " " + Resource.Name.ToLower() + " per turn.";
-			}
-		}
+		public override string FullDescription => IsPercentage
+					? $"{Giver.WeOrName()} will pay {Receiver.UsOrName()} a tribute of {Quantity}% of {Giver.WeOrName(false).Possessive()} gross {Resource.Name.ToLower()} income."
+					: $"{Giver.WeOrName()} will pay {Receiver.UsOrName()} a tribute of {Quantity.ToUnitString(true)} {Resource.Name.ToLower()} per turn.";
 
 		/// <summary>
 		/// Is this a percentage or a flat rate?
@@ -69,11 +53,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy.Clauses
 		/// <summary>
 		/// The resource being traded.
 		/// </summary>
-		public Resource Resource
-		{
-			get;
-			set;
-		}
+		public Resource Resource { get; set; }
 
 		public override void PerformAction()
 		{

--- a/FrEee/Game/Objects/Civilization/Diplomacy/DeclareWarAction.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/DeclareWarAction.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
@@ -12,10 +14,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		{
 		}
 
-		public override string Description
-		{
-			get { return "Declare War"; }
-		}
+		public override string Description => "Declare War";
 
 		public override void Execute()
 		{

--- a/FrEee/Game/Objects/Civilization/Diplomacy/DeclareWarAction.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/DeclareWarAction.cs
@@ -18,11 +18,14 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 
 		public override void Execute()
 		{
+			if (Executor is null)
+				return;
+
 			foreach (var clause in Executor.GetTreaty(Target))
 				clause.Dispose();
 			// TODO - some sort of formal war state
 			Executor.Log.Add(Target.CreateLogMessage("We have declared war on the " + Target + ".", LogMessages.LogMessageType.Diplomacy));
-			Target.Log.Add(Executor.CreateLogMessage("The " + Executor + " has declared war on us!", LogMessages.LogMessageType.Diplomacy));
+			Target?.Log.Add(Executor.CreateLogMessage("The " + Executor + " has declared war on us!", LogMessages.LogMessageType.Diplomacy));
 		}
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Diplomacy/GeneralMessage.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/GeneralMessage.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
@@ -13,21 +15,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		{
 		}
 
-		public override IEnumerable<string> IconPaths
-		{
-			get
-			{
-				return Owner.IconPaths;
-			}
-		}
+		public override IEnumerable<string> IconPaths => Owner.IconPaths;
 
-		public override IEnumerable<string> PortraitPaths
-		{
-			get
-			{
-				return Owner.PortraitPaths;
-			}
-		}
+		public override IEnumerable<string> PortraitPaths => Owner.PortraitPaths;
 
 		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done)
 		{

--- a/FrEee/Game/Objects/Civilization/Diplomacy/GeneralMessage.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/GeneralMessage.cs
@@ -15,11 +15,11 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		{
 		}
 
-		public override IEnumerable<string> IconPaths => Owner.IconPaths;
+		public override IEnumerable<string>? IconPaths => Owner?.IconPaths;
 
-		public override IEnumerable<string> PortraitPaths => Owner.PortraitPaths;
+		public override IEnumerable<string>? PortraitPaths => Owner?.PortraitPaths;
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done)
 		{
 			// nothing to do
 		}

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Message.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Message.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Commands;
 using FrEee.Game.Objects.Space;
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
 	/// <summary>
@@ -15,56 +17,40 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 	/// </summary>
 	public abstract class Message : IMessage
 	{
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+		// initialized via property
 		protected Message(Empire recipient)
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 		{
 			Owner = Empire.Current;
 			Recipient = recipient;
 			TurnNumber = Galaxy.Current.TurnNumber;
 		}
 
-		public Image Icon
-		{
-			get
-			{
-				return Owner == Empire.Current ? Recipient.Icon : Owner.Icon;
-			}
-		}
+		public Image Icon => Owner == Empire.Current ? Recipient.Icon : Owner.Icon;
 
 		public Image Icon32 => Icon.Resize(32);
 
 		public abstract IEnumerable<string> IconPaths { get; }
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
-		public IMessage InReplyTo { get; set; }
+		public IMessage? InReplyTo { get; set; }
 
 		public bool IsDisposed { get; set; }
 
 		/// <summary>
 		/// Messages cannot be memories, as they do not change over time.
 		/// </summary>
-		public bool IsMemory
-		{
-			get; set;
-		}
+		public bool IsMemory { get; set; }
 
 		/// <summary>
 		/// The empire sending this message.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire Owner { get => owner; set => owner = value; }
 
-		public Image Portrait
-		{
-			get
-			{
-				return Owner == Empire.Current ? Recipient.Portrait : Owner?.Portrait;
-			}
-		}
+		public Image? Portrait => Owner == Empire.Current ? Recipient.Portrait : Owner?.Portrait;
 
 		public abstract IEnumerable<string> PortraitPaths { get; }
 
@@ -72,17 +58,14 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// The empire receiving the message.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Recipient { get { return recipient; } set { recipient = value; } }
+		public Empire Recipient { get => recipient; set => recipient = value; }
 
 		/// <summary>
 		/// The text of the message.
 		/// </summary>
-		public string Text { get; set; }
+		public string? Text { get; set; }
 
-		public double Timestamp
-		{
-			get; set;
-		}
+		public double Timestamp { get; set; }
 
 		public int TurnNumber { get; set; }
 
@@ -117,10 +100,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// <summary>
 		/// Messages cannot be memories, as they do not change over time.
 		/// </summary>
-		public bool IsObsoleteMemory(Empire emp)
-		{
-			return false;
-		}
+		public bool IsObsoleteMemory(Empire emp) => false;
 
 		public void Redact(Empire emp)
 		{
@@ -130,6 +110,6 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 				Dispose();
 		}
 
-		public abstract void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null);
+		public abstract void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null);
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Message.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Message.cs
@@ -27,11 +27,11 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 			TurnNumber = Galaxy.Current.TurnNumber;
 		}
 
-		public Image Icon => Owner == Empire.Current ? Recipient.Icon : Owner.Icon;
+		public Image? Icon => Owner == Empire.Current ? Recipient.Icon : Owner?.Icon;
 
 		public Image Icon32 => Icon.Resize(32);
 
-		public abstract IEnumerable<string> IconPaths { get; }
+		public abstract IEnumerable<string>? IconPaths { get; }
 
 		public long ID { get; set; }
 
@@ -48,11 +48,11 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// The empire sending this message.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get => owner; set => owner = value; }
+		public Empire? Owner { get => owner; set => owner = value; }
 
 		public Image? Portrait => Owner == Empire.Current ? Recipient.Portrait : Owner?.Portrait;
 
-		public abstract IEnumerable<string> PortraitPaths { get; }
+		public abstract IEnumerable<string>? PortraitPaths { get; }
 
 		/// <summary>
 		/// The empire receiving the message.
@@ -69,7 +69,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 
 		public int TurnNumber { get; set; }
 
-		private GalaxyReference<Empire> owner { get; set; }
+		private GalaxyReference<Empire?> owner { get; set; }
 
 		private GalaxyReference<Empire> recipient { get; set; }
 

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Package.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Package.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization.Diplomacy.Clauses;
 using FrEee.Game.Objects.Space;
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Tech = FrEee.Game.Objects.Technology.Technology;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
 	/// <summary>
@@ -16,7 +18,10 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 	/// </summary>
 	public class Package : IOwnable, IPromotable
 	{
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+		// initialized via property
 		public Package(Empire owner, Empire recipient)
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 		{
 			Owner = owner;
 			Recipient = recipient;
@@ -76,32 +81,20 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 			}
 		}
 
-		public bool IsEmpty
-		{
-			get
-			{
-				return !TreatyClauses.Any() && !Planets.Any() && !Vehicles.Any() && !Resources.Any(r => r.Value != 0) && !Technology.Any() && !StarCharts.Any() && !CommunicationChannels.Any();
-			}
-		}
+		public bool IsEmpty => !TreatyClauses.Any() && !Planets.Any() && !Vehicles.Any() && !Resources.Any(r => r.Value != 0) && !Technology.Any() && !StarCharts.Any() && !CommunicationChannels.Any();
 
 		/// <summary>
 		/// Is this a valid package?
 		/// </summary>
-		public bool IsValid
-		{
-			get
-			{
-				return !Errors.Any();
-			}
-		}
+		public bool IsValid => !Errors.Any();
 
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire Owner { get => owner; set => owner = value; }
 
 		public GalaxyReferenceSet<Planet> Planets { get; private set; }
 
 		[DoNotSerialize]
-		public Empire Recipient { get { return recipient; } set { recipient = value; } }
+		public Empire Recipient { get => recipient; set => recipient = value; }
 
 		public ResourceQuantity Resources { get; private set; }
 		public GalaxyReferenceSet<StarSystem> StarCharts { get; private set; }
@@ -112,7 +105,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		private GalaxyReference<Empire> owner { get; set; }
 		private GalaxyReference<Empire> recipient { get; set; }
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();
@@ -126,7 +119,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 
 		public override string ToString()
 		{
-			var items = new List<string>();
+			var items = new List<string?>();
 			if (TreatyClauses.Any())
 			{
 				if (TreatyClauses.Count == 1)

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Package.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Package.cs
@@ -176,8 +176,11 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// Transfers this package to a target empire.
 		/// </summary>
 		/// <param name="target"></param>
-		public void Transfer(Empire target)
+		public void Transfer(Empire? target)
 		{
+			if (target is null)
+				return;
+
 			var errors = Errors.ToArray();
 			if (errors.Any())
 				throw new Exception("Attempting to transfer an invalid package (" + this + "): " + errors.First());

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Proposal.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Proposal.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Commands;
 using FrEee.Game.Objects.Space;
@@ -7,6 +7,8 @@ using FrEee.Utility.Extensions;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
 	/// <summary>
@@ -14,7 +16,10 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 	/// </summary>
 	public class Proposal : Command<Empire>, IFoggable, IReferrable
 	{
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+		// initialized via property
 		public Proposal(Empire recipient)
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 			: base(Empire.Current)
 		{
 			Timestamp = Galaxy.Current.TurnNumber;
@@ -38,19 +43,11 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// <summary>
 		/// The package being given.
 		/// </summary>
-		public Package GivePackage { get; set; }
+		public Package? GivePackage { get; set; }
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
-		public bool IsMemory
-		{
-			get;
-			set;
-		}
+		public bool IsMemory { get; set; }
 
 		/// <summary>
 		/// No fair accepting a gift twice!
@@ -61,33 +58,22 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// Is this a tentative offer?
 		/// Tentative offers cannot be accepted; instead they must be countered.
 		/// </summary>
-		public bool IsTentative
-		{
-			get;
-			set;
-		}
+		public bool IsTentative { get; set; }
 
-		public Empire Owner
-		{
-			get { return Executor; }
-		}
+		public Empire Owner => Executor;
 
 		/// <summary>
 		/// The package being received in return.
 		/// </summary>
-		public Package ReceivePackage { get; set; }
+		public Package? ReceivePackage { get; set; }
 
 		/// <summary>
 		/// The empire that the proposal is being sent to.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Recipient { get { return recipient; } set { recipient = value; } }
+		public Empire Recipient { get => recipient; set => recipient = value; }
 
-		public double Timestamp
-		{
-			get;
-			set;
-		}
+		public double Timestamp { get; set; }
 
 		private GalaxyReference<Empire> recipient { get; set; }
 
@@ -110,8 +96,8 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 
 		public override void Execute()
 		{
-			var errors = GivePackage.Errors.Concat(ReceivePackage.Errors);
-			if (errors.Any())
+			var errors = GivePackage?.Errors.Concat(ReceivePackage?.Errors);
+			if (errors?.Any() ?? false)
 			{
 				Executor.Log.Add(Recipient.CreateLogMessage("We could not execute a trade with the " + Recipient + " because: " + errors.First(), LogMessages.LogMessageType.Error));
 				Recipient.Log.Add(Executor.CreateLogMessage("We could not execute a trade with the " + Executor + " because: " + errors.First(), LogMessages.LogMessageType.Error));
@@ -125,10 +111,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 			}
 		}
 
-		public bool IsObsoleteMemory(Empire emp)
-		{
-			return false;
-		}
+		public bool IsObsoleteMemory(Empire emp) => false;
 
 		public void Redact(Empire emp)
 		{
@@ -136,7 +119,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 				Dispose();
 		}
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();
@@ -148,14 +131,8 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 			}
 		}
 
-		public override string ToString()
-		{
-			return Description;
-		}
+		public override string ToString() => Description;
 
-		private bool IsNullOrEmpty(Package package)
-		{
-			return package == null || package.IsEmpty;
-		}
+		private bool IsNullOrEmpty(Package? package) => package == null || package.IsEmpty;
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Diplomacy/Proposal.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/Proposal.cs
@@ -60,7 +60,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		/// </summary>
 		public bool IsTentative { get; set; }
 
-		public Empire Owner => Executor;
+		public Empire? Owner => Executor;
 
 		/// <summary>
 		/// The package being received in return.
@@ -99,7 +99,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 			var errors = GivePackage?.Errors.Concat(ReceivePackage?.Errors);
 			if (errors?.Any() ?? false)
 			{
-				Executor.Log.Add(Recipient.CreateLogMessage("We could not execute a trade with the " + Recipient + " because: " + errors.First(), LogMessages.LogMessageType.Error));
+				Executor?.Log.Add(Recipient.CreateLogMessage("We could not execute a trade with the " + Recipient + " because: " + errors.First(), LogMessages.LogMessageType.Error));
 				Recipient.Log.Add(Executor.CreateLogMessage("We could not execute a trade with the " + Executor + " because: " + errors.First(), LogMessages.LogMessageType.Error));
 			}
 			else

--- a/FrEee/Game/Objects/Civilization/Diplomacy/ProposalMessage.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/ProposalMessage.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
@@ -18,28 +20,16 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 			Proposal = new Proposal(recipient);
 		}
 
-		public override IEnumerable<string> IconPaths
-		{
-			get
-			{
-				return Proposal.Owner.IconPaths;
-			}
-		}
+		public override IEnumerable<string> IconPaths => Proposal.Owner.IconPaths;
 
-		public override IEnumerable<string> PortraitPaths
-		{
-			get
-			{
-				return Proposal.Owner.PortraitPaths;
-			}
-		}
+		public override IEnumerable<string> PortraitPaths => Proposal.Owner.PortraitPaths;
 
 		/// <summary>
 		/// The proposal in question.
 		/// </summary>
 		public Proposal Proposal { get; set; }
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();

--- a/FrEee/Game/Objects/Civilization/Diplomacy/ProposalMessage.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/ProposalMessage.cs
@@ -20,9 +20,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 			Proposal = new Proposal(recipient);
 		}
 
-		public override IEnumerable<string> IconPaths => Proposal.Owner.IconPaths;
+		public override IEnumerable<string>? IconPaths => Proposal.Owner?.IconPaths;
 
-		public override IEnumerable<string> PortraitPaths => Proposal.Owner.PortraitPaths;
+		public override IEnumerable<string>? PortraitPaths => Proposal.Owner?.PortraitPaths;
 
 		/// <summary>
 		/// The proposal in question.

--- a/FrEee/Game/Objects/Civilization/Diplomacy/RejectProposalAction.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/RejectProposalAction.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization.Diplomacy
 {
@@ -11,22 +13,22 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 	/// <typeparam name="T"></typeparam>
 	public class RejectProposalAction : Action
 	{
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+		// initialized via property
 		public RejectProposalAction(Proposal proposal)
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 			: base(proposal.Executor)
 		{
 			Proposal = proposal;
 		}
 
-		public override string Description
-		{
-			get { return "Reject " + Proposal; }
-		}
+		public override string Description => $"Reject {Proposal}";
 
 		/// <summary>
 		/// The proposal in question.
 		/// </summary>
 		[DoNotSerialize]
-		public Proposal Proposal { get { return proposal; } set { proposal = value; } }
+		public Proposal Proposal { get => proposal; set => proposal = value; }
 
 		private GalaxyReference<Proposal> proposal { get; set; }
 
@@ -38,7 +40,7 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 				Target.Log.Add(Executor.CreateLogMessage("The " + Executor + " has rejected our proposal (" + Proposal + ").", LogMessages.LogMessageType.Diplomacy));
 		}
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();

--- a/FrEee/Game/Objects/Civilization/Diplomacy/RejectProposalAction.cs
+++ b/FrEee/Game/Objects/Civilization/Diplomacy/RejectProposalAction.cs
@@ -35,9 +35,9 @@ namespace FrEee.Game.Objects.Civilization.Diplomacy
 		public override void Execute()
 		{
 			if (Proposal.IsResolved)
-				Executor.Log.Add(Target.CreateLogMessage("The proposal \"" + Proposal + "\" has already been resolved and cannot be rejected now.", LogMessages.LogMessageType.Error));
+				Executor?.Log.Add(Target.CreateLogMessage("The proposal \"" + Proposal + "\" has already been resolved and cannot be rejected now.", LogMessages.LogMessageType.Error));
 			else
-				Target.Log.Add(Executor.CreateLogMessage("The " + Executor + " has rejected our proposal (" + Proposal + ").", LogMessages.LogMessageType.Diplomacy));
+				Target?.Log.Add(Executor.CreateLogMessage("The " + Executor + " has rejected our proposal (" + Proposal + ").", LogMessages.LogMessageType.Diplomacy));
 		}
 
 		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)

--- a/FrEee/Game/Objects/Civilization/Empire.cs
+++ b/FrEee/Game/Objects/Civilization/Empire.cs
@@ -914,7 +914,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// </summary>
 		/// <param name="other"></param>
 		/// <returns></returns>
-		public bool IsEnemyOf(Empire other, StarSystem sys)
+		public bool IsEnemyOf(Empire other, StarSystem? sys)
 		{
 			if (other == null)
 				return false; // can't be hostile to nobody/host
@@ -1248,9 +1248,9 @@ namespace FrEee.Game.Objects.Civilization
 		/// Triggers a happiness change in a star system.
 		/// </summary>
 		/// <param name="trigger">The trigger function.</param>
-		public void TriggerHappinessChange(StarSystem s, Func<HappinessModel, int> trigger)
+		public void TriggerHappinessChange(StarSystem? s, Func<HappinessModel, int> trigger)
 		{
-			foreach (var colony in s.FindSpaceObjects<Planet>().Where(p => p.Owner == this).Select(p => p.Colony))
+			foreach (var colony in s?.FindSpaceObjects<Planet>().Where(p => p.Owner == this).Select(p => p.Colony) ?? Enumerable.Empty<Colony>())
 				colony.TriggerHappinessChange(trigger);
 		}
 
@@ -1258,9 +1258,9 @@ namespace FrEee.Game.Objects.Civilization
 		/// Triggers a happiness change in a sector.
 		/// </summary>
 		/// <param name="trigger">The trigger function.</param>
-		public void TriggerHappinessChange(Sector s, Func<HappinessModel, int> trigger)
+		public void TriggerHappinessChange(Sector? s, Func<HappinessModel, int> trigger)
 		{
-			foreach (var colony in s.SpaceObjects.OfType<Planet>().Where(p => p.Owner == this).Select(p => p.Colony))
+			foreach (var colony in s?.SpaceObjects.OfType<Planet>().Where(p => p.Owner == this).Select(p => p.Colony) ?? Enumerable.Empty<Colony>())
 				colony.TriggerHappinessChange(trigger);
 		}
 

--- a/FrEee/Game/Objects/Civilization/Empire.cs
+++ b/FrEee/Game/Objects/Civilization/Empire.cs
@@ -88,7 +88,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// The names of any ministers that are enabled, keyed by category.
 		/// </summary>
-		public SafeDictionary<string, ICollection<string>>? EnabledMinisters { get; set; }
+		public SafeDictionary<string, ICollection<string>> EnabledMinisters { get; set; }
 
 		// HACK - we are loading up the Galaxy Seen ability way too many times during pathfinding and this is slowing it down massively.
 		// yes, this means that an empire gaining/losing this ability would have to wait until the next turn to actually gain or lose it
@@ -769,7 +769,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// Computes the score of this empire.
 		/// </summary>
 		/// <param name="viewer">The empire viewing this empire's score, or null for the host view. If the score isn't meant to be visible, it will be set to null.</param>
-		public int? ComputeScore(Empire viewer)
+		public int? ComputeScore(Empire? viewer)
 		{
 			// can we see it?
 			// TODO - rankings too, not just scores
@@ -1028,7 +1028,7 @@ namespace FrEee.Game.Objects.Civilization
 			// eliminate memories of objects that are actually visible
 			foreach (var kvp in Memory.ToArray())
 			{
-				var original = (IFoggable)Galaxy.Current.GetReferrable(kvp.Key);
+				var original = (IFoggable?)Galaxy.Current.GetReferrable(kvp.Key);
 				if (original != null && original.CheckVisibility(emp) >= Visibility.Visible)
 				{
 					kvp.Value.Dispose();

--- a/FrEee/Game/Objects/Civilization/Empire.cs
+++ b/FrEee/Game/Objects/Civilization/Empire.cs
@@ -60,7 +60,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// The current empire being controlled by the player.
 		/// </summary>
-		public static Empire? Current => Galaxy.Current?.CurrentEmpire;
+		public static Empire Current => Galaxy.Current.CurrentEmpire;
 
 		/// <summary>
 		/// Information about the player controlling this empire.

--- a/FrEee/Game/Objects/Civilization/Empire.cs
+++ b/FrEee/Game/Objects/Civilization/Empire.cs
@@ -811,7 +811,7 @@ namespace FrEee.Game.Objects.Civilization
 			foreach (var x in OwnedSpaceObjects.OfType<SpaceVehicle>().ToArray())
 				x.Dispose();
 			foreach (var x in ColonizedPlanets.ToArray())
-				x.Colony.Dispose();
+				x.Colony?.Dispose();
 		}
 
 		/// <summary>

--- a/FrEee/Game/Objects/Civilization/Empire.cs
+++ b/FrEee/Game/Objects/Civilization/Empire.cs
@@ -868,8 +868,12 @@ namespace FrEee.Game.Objects.Civilization
 		/// </summary>
 		/// <param name="emp"></param>
 		/// <returns></returns>
-		public IEnumerable<Clause> GetTreaty(Empire emp)
+		public IEnumerable<Clause> GetTreaty(Empire? emp)
 		{
+			if (emp is null)
+			{
+				return Enumerable.Empty<Clause>();
+			}
 			return GivenTreatyClauses[emp].Union(ReceivedTreatyClauses[emp]);
 		}
 
@@ -890,8 +894,12 @@ namespace FrEee.Game.Objects.Civilization
 		/// </summary>
 		/// <param name="item"></param>
 		/// <returns></returns>
-		public bool HasUnlocked(IUnlockable item)
+		public bool HasUnlocked(IUnlockable? item)
 		{
+			if (item is null)
+			{
+				return false;
+			}
 			return CheckUnlockStatus(item);
 			// TODO - fix caching of unlock status
 			//			return item == null || UnlockedItems.Contains(item);

--- a/FrEee/Game/Objects/Civilization/Empire.cs
+++ b/FrEee/Game/Objects/Civilization/Empire.cs
@@ -45,12 +45,12 @@ namespace FrEee.Game.Objects.Civilization
 			UniqueTechsFound = new List<string>();
 			Memory = new SafeDictionary<long, IFoggable>();
 			AINotes = new DynamicDictionary();
-			PlayerNotes = new SafeDictionary<GalaxyReference<IReferrable>, string>();
-			PrivateNames = new SafeDictionary<GalaxyReference<INameable>, string>();
+			PlayerNotes = new SafeDictionary<GalaxyReference<IReferrable?>, string>();
+			PrivateNames = new SafeDictionary<GalaxyReference<INameable?>, string?>();
 			EncounteredEmpires = new HashSet<Empire>();
 			EncounteredEmpires.Add(this);
-			IncomingMessages = new HashSet<IMessage>();
-			SentMessages = new HashSet<IMessage>();
+			IncomingMessages = new HashSet<IMessage?>();
+			SentMessages = new HashSet<IMessage?>();
 			Waypoints = new List<Waypoint>();
 			NumberedWaypoints = new Waypoint[10];
 			Scores = new SafeDictionary<int, int?>();
@@ -88,7 +88,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// The names of any ministers that are enabled, keyed by category.
 		/// </summary>
-		public SafeDictionary<string, ICollection<string>> EnabledMinisters { get; set; }
+		public SafeDictionary<string, ICollection<string>>? EnabledMinisters { get; set; }
 
 		// HACK - we are loading up the Galaxy Seen ability way too many times during pathfinding and this is slowing it down massively.
 		// yes, this means that an empire gaining/losing this ability would have to wait until the next turn to actually gain or lose it
@@ -252,7 +252,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// Incoming messages that are awaiting a response.
 		/// </summary>
-		public ICollection<IMessage> IncomingMessages { get; private set; }
+		public ICollection<IMessage?> IncomingMessages { get; private set; }
 
 		/// <summary>
 		/// The name of the insignia picture file, relative to Pictures/Insignia.
@@ -376,7 +376,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// Notes set by the player on various game objects.
 		/// </summary>
-		public SafeDictionary<GalaxyReference<IReferrable>, string> PlayerNotes { get; private set; }
+		public SafeDictionary<GalaxyReference<IReferrable?>, string> PlayerNotes { get; private set; }
 
 		/// <summary>
 		/// The leader portrait for this empire.
@@ -404,7 +404,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// Privately visible names set by the player on various game objects.
 		/// </summary>
-		public SafeDictionary<GalaxyReference<INameable>, string> PrivateNames { get; private set; }
+		public SafeDictionary<GalaxyReference<INameable?>, string?> PrivateNames { get; private set; }
 
 		/// <summary>
 		/// Income via raw resource generation ("Generate Points") abilities (not standard or remote mining, or standard point generation).
@@ -602,7 +602,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// Messages sent by this empire.
 		/// </summary>
-		public ICollection<IMessage> SentMessages { get; private set; }
+		public ICollection<IMessage?> SentMessages { get; private set; }
 
 		/// <summary>
 		/// The name of the shipset, relative to Pictures/Shipsets.

--- a/FrEee/Game/Objects/Civilization/EmpireStatus.cs
+++ b/FrEee/Game/Objects/Civilization/EmpireStatus.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Objects.Space;
+using FrEee.Game.Objects.Space;
 using System.Drawing;
 using System.IO;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -16,10 +18,10 @@ namespace FrEee.Game.Objects.Civilization
 
 		public Empire Empire { get; set; }
 
-		public Image Insignia { get { return Empire.Icon; } }
-		public bool IsDefeated { get { return Empire.IsDefeated; } }
-		public bool IsPlayerEmpire { get { return Empire.IsPlayerEmpire; } }
-		public string Name { get { return Empire.Name; } }
+		public Image Insignia => Empire.Icon;
+		public bool IsDefeated => Empire.IsDefeated;
+		public bool IsPlayerEmpire => Empire.IsPlayerEmpire;
+		public string? Name => Empire.Name;
 
 		public PlrUploadStatus PlrUploadStatus
 		{

--- a/FrEee/Game/Objects/Civilization/HappinessModel.cs
+++ b/FrEee/Game/Objects/Civilization/HappinessModel.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Modding;
+using FrEee.Modding;
 using FrEee.Modding.Interfaces;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -18,22 +20,19 @@ namespace FrEee.Game.Objects.Civilization
 		public int BattleInSystemLoss { get; set; }
 		public int BattleInSystemStalemate { get; set; }
 		public int BattleInSystemWin { get; set; }
-		public string Description { get; set; }
+		public string? Description { get; set; }
 		public int EnemyPlanetCaptured { get; set; }
 		public int EnemyShipInSector { get; set; }
 		public int EnemyShipInSystem { get; set; }
 		public int EnemyTroopsOnPlanet { get; set; }
 		public int FacilityConstructed { get; set; }
 
-		public bool IsDisposed
-		{
-			get; private set;
-		}
+		public bool IsDisposed { get; private set; }
 
 		public int MaxNegativeTurnAngerChange { get; set; }
 		public int MaxPositiveTurnAngerChange { get; set; }
-		public string ModID { get; set; }
-		public string Name { get; set; }
+		public string? ModID { get; set; }
+		public string? Name { get; set; }
 		public int NaturalTurnAngerChangeOtherRaces { get; set; }
 		public int NaturalTurnAngerChangeOurRace { get; set; }
 		public int OneMillionPopulationKilled { get; set; }
@@ -53,7 +52,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// Parameters from the mod meta templates.
 		/// </summary>
-		public IDictionary<string, object> TemplateParameters { get; set; }
+		public IDictionary<string, object>? TemplateParameters { get; set; }
 
 		public int TreatyMilitaryAlliance { get; set; }
 		public int TreatyNonAggression { get; set; }
@@ -74,9 +73,6 @@ namespace FrEee.Game.Objects.Civilization
 			IsDisposed = true;
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name ?? string.Empty;
 	}
 }

--- a/FrEee/Game/Objects/Civilization/PlayerInfo.cs
+++ b/FrEee/Game/Objects/Civilization/PlayerInfo.cs
@@ -1,10 +1,8 @@
-﻿using FrEee.Game.Interfaces;
-using FrEee.Utility;
-using System;
+using FrEee.Game.Interfaces;
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -13,21 +11,21 @@ namespace FrEee.Game.Objects.Civilization
 	/// </summary>
 	public class PlayerInfo : IPromotable
 	{
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
-		public string Email { get; set; }
+		public string? Email { get; set; }
 
-		public string Pbw { get; set; }
+		public string? Pbw { get; set; }
 
-		public string Irc { get; set; }
+		public string? Irc { get; set; }
 
-		public string Discord { get; set; }
+		public string? Discord { get; set; }
 
-		public string Website { get; set; }
+		public string? Website { get; set; }
 
-		public string Notes { get; set; }
+		public string? Notes { get; set; }
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			// nothing to do here
 		}

--- a/FrEee/Game/Objects/Civilization/Race.cs
+++ b/FrEee/Game/Objects/Civilization/Race.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Abilities;
 using FrEee.Game.Objects.Space;
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -25,15 +27,9 @@ namespace FrEee.Game.Objects.Civilization
 			Aptitudes = new SafeDictionary<string, int>();
 		}
 
-		public IEnumerable<Ability> Abilities
-		{
-			get { return Traits.SelectMany(t => t.Abilities); }
-		}
+		public IEnumerable<Ability> Abilities => Traits.SelectMany(t => t.Abilities);
 
-		public AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.Race; }
-		}
+		public AbilityTargets AbilityTarget => AbilityTargets.Race;
 
 		/// <summary>
 		/// Aptitudes of this race.
@@ -41,10 +37,7 @@ namespace FrEee.Game.Objects.Civilization
 		// TODO - convert to NamedDictionary
 		public IDictionary<string, int> Aptitudes { get; private set; }
 
-		public IEnumerable<IAbilityObject> Children
-		{
-			get { return Traits; }
-		}
+		public IEnumerable<IAbilityObject> Children => Traits;
 
 		/// <summary>
 		/// The race's happiness model.
@@ -55,10 +48,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// The population icon.
 		/// </summary>
-		public Image Icon
-		{
-			get { return Pictures.GetIcon(this); }
-		}
+		public Image Icon => Pictures.GetIcon(this);
 
 		public Image Icon32 => Icon.Resize(32);
 
@@ -88,7 +78,7 @@ namespace FrEee.Game.Objects.Civilization
 				foreach (var r in Resource.All)
 				{
 					var factor = 1d;
-					if (r.Aptitude != null)
+					if (r.Aptitude?.Name != null)
 						factor *= Aptitudes[r.Aptitude.Name] / 100d;
 					result += (int)(100 * factor) * r;
 				}
@@ -106,25 +96,22 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// The name of this race. Also used for picture names.
 		/// </summary>
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
 		/// <summary>
 		/// The atmosphere which this race breathes.
 		/// </summary>
-		public string NativeAtmosphere { get; set; }
+		public string? NativeAtmosphere { get; set; }
 
 		/// <summary>
 		/// The native planet surface type of this race.
 		/// </summary>
-		public string NativeSurface { get; set; }
+		public string? NativeSurface { get; set; }
 
 		/// <summary>
 		/// Races have no owner.
 		/// </summary>
-		public Empire Owner
-		{
-			get { return null; }
-		}
+		public Empire? Owner => null;
 
 		public IEnumerable<IAbilityObject> Parents
 		{
@@ -138,23 +125,14 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// The population icon name for this race.
 		/// </summary>
-		public string PopulationIconName { get; set; }
+		public string? PopulationIconName { get; set; }
 
 		/// <summary>
 		/// The population portrait.
 		/// </summary>
-		public Image Portrait
-		{
-			get { return Pictures.GetPortrait(this); }
-		}
+		public Image Portrait => Pictures.GetPortrait(this);
 
-		public IEnumerable<string> PortraitPaths
-		{
-			get
-			{
-				return IconPaths;
-			}
-		}
+		public IEnumerable<string> PortraitPaths => IconPaths;
 
 		/// <summary>
 		/// The names of the race's traits.
@@ -164,12 +142,9 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// The traits of the race.
 		/// </summary>
-		public IEnumerable<Trait> Traits { get { return Mod.Current.Traits.Join(TraitNames, t => t.Name, n => n, (t, n) => t); } }
+		public IEnumerable<Trait> Traits => Mod.Current.Traits.Join(TraitNames, t => t.Name, n => n, (t, n) => t);
 
-		public IEnumerable<Ability> UnstackedAbilities
-		{
-			get { return Abilities; }
-		}
+		public IEnumerable<Ability> UnstackedAbilities => Abilities;
 
 		public IEnumerable<string> Warnings
 		{
@@ -200,7 +175,7 @@ namespace FrEee.Game.Objects.Civilization
 			}
 		}
 
-		private ModReference<HappinessModel> happinessModel { get; set; }
+		private ModReference<HappinessModel>? happinessModel { get; set; }
 
 		public static Race Load(string filename)
 		{
@@ -215,11 +190,8 @@ namespace FrEee.Game.Objects.Civilization
 		/// </summary>
 		/// <param name="emp"></param>
 		/// <returns></returns>
-		public Visibility CheckVisibility(Empire emp)
-		{
-			// TODO - hide races until first contact
-			return Visibility.Scanned;
-		}
+		// TODO - hide races until first contact
+		public Visibility CheckVisibility(Empire emp) => Visibility.Scanned;
 
 		public void Dispose()
 		{
@@ -235,13 +207,15 @@ namespace FrEee.Game.Objects.Civilization
 			fs.Close(); fs.Dispose();
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name ?? string.Empty;
 
-		private IEnumerable<string> GetImagePaths(string imagename, string imagetype)
+		private IEnumerable<string> GetImagePaths(string? imagename, string imagetype)
 		{
+			if (imagename is null)
+			{
+				throw new ArgumentNullException(nameof(imagename));
+			}
+
 			if (Mod.Current?.RootPath != null)
 			{
 				yield return Path.Combine("Mods", Mod.Current.RootPath, "Pictures", "Races", imagename, imagetype);

--- a/FrEee/Game/Objects/Civilization/SectorWaypoint.cs
+++ b/FrEee/Game/Objects/Civilization/SectorWaypoint.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Game.Objects.Space;
+using FrEee.Game.Objects.Space;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -8,25 +10,12 @@ namespace FrEee.Game.Objects.Civilization
 	public class SectorWaypoint : Waypoint
 	{
 		public SectorWaypoint(Sector sector)
-			: base()
-		{
-			Sector = sector;
-		}
+			: base() => Sector = sector;
 
-		public override string Name
-		{
-			get { return "Waypoint at " + Sector.Name; }
-		}
+		public override string Name => "Waypoint at " + Sector?.Name;
 
-		public override Sector Sector
-		{
-			get;
-			set;
-		}
+		public override Sector? Sector { get; set; }
 
-		public override StarSystem StarSystem
-		{
-			get { return Sector.StarSystem; }
-		}
+		public override StarSystem? StarSystem => Sector?.StarSystem;
 	}
 }

--- a/FrEee/Game/Objects/Civilization/SpaceObjectWaypoint.cs
+++ b/FrEee/Game/Objects/Civilization/SpaceObjectWaypoint.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Space;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -11,40 +13,22 @@ namespace FrEee.Game.Objects.Civilization
 	/// </summary>
 	public class SpaceObjectWaypoint : Waypoint
 	{
-		public SpaceObjectWaypoint(ISpaceObject sobj)
-		{
-			SpaceObject = sobj;
-		}
+		public SpaceObjectWaypoint(ISpaceObject sobj) => SpaceObject = sobj;
 
-		public override string Name
-		{
-			get { return "Waypoint at " + SpaceObject.Name; }
-		}
+		public override string Name => "Waypoint at " + SpaceObject?.Name;
 
 		[DoNotSerialize(false)]
-		public override Sector Sector
+		public override Sector? Sector
 		{
-			get
-			{
-				return SpaceObject?.Sector;
-			}
-			set
-			{
-				throw new InvalidOperationException("Cannot set the sector of a space object waypoint.");
-			}
+			get => SpaceObject?.Sector;
+			set => throw new InvalidOperationException("Cannot set the sector of a space object waypoint.");
 		}
 
 		[DoNotSerialize]
-		public ISpaceObject SpaceObject { get { return spaceObject.Value; } set { spaceObject = value.ReferViaGalaxy(); } }
+		public ISpaceObject? SpaceObject { get => spaceObject?.Value; set => spaceObject = value?.ReferViaGalaxy(); }
 
-		public override StarSystem StarSystem
-		{
-			get
-			{
-				return SpaceObject.StarSystem;
-			}
-		}
+		public override StarSystem? StarSystem => SpaceObject?.StarSystem;
 
-		private GalaxyReference<ISpaceObject> spaceObject { get; set; }
+		private GalaxyReference<ISpaceObject>? spaceObject { get; set; }
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Trait.cs
+++ b/FrEee/Game/Objects/Civilization/Trait.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Abilities;
 using FrEee.Modding;
@@ -7,6 +7,8 @@ using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -28,10 +30,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// </summary>
 		public IList<Ability> Abilities { get; private set; }
 
-		public AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.Trait; }
-		}
+		public AbilityTargets AbilityTarget => AbilityTargets.Trait;
 
 		public IEnumerable<IAbilityObject> Children
 		{
@@ -41,14 +40,14 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// The cost of this trait, in empire points.
 		/// </summary>
-		public Formula<int> Cost { get; set; }
+		public Formula<int>? Cost { get; set; }
 
-		public Formula<string> Description { get; set; }
+		public Formula<string>? Description { get; set; }
 
 		/// <summary>
 		/// TODO - trait pictures
 		/// </summary>
-		public Image Icon { get { return null; } }
+		public Image? Icon => null;
 
 		public Image Icon32 => Icon.Resize(32);
 
@@ -60,29 +59,16 @@ namespace FrEee.Game.Objects.Civilization
 			}
 		}
 
-		public IEnumerable<Ability> IntrinsicAbilities
-		{
-			get { return Abilities; }
-		}
+		public IEnumerable<Ability> IntrinsicAbilities => Abilities;
 
-		public bool IsDisposed
-		{
-			// TODO - disposable traits?
-			get { return false; }
-		}
+		// TODO - disposable traits?
+		public bool IsDisposed => false;
 
-		public string ModID { get; set; }
+		public string? ModID { get; set; }
 
-		public string Name
-		{
-			get;
-			set;
-		}
+		public string? Name { get; set; }
 
-		string INamed.Name
-		{
-			get { return Name; }
-		}
+		string? INamed.Name => Name;
 
 		public IEnumerable<IAbilityObject> Parents
 		{
@@ -95,7 +81,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// TODO - trait pictures
 		/// </summary>
-		public Image Portrait { get { return null; } }
+		public Image? Portrait => null;
 
 		public IEnumerable<string> PortraitPaths
 		{
@@ -110,10 +96,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// </summary>
 		public IList<Trait> RequiredTraits { get; private set; }
 
-		public string ResearchGroup
-		{
-			get { return "Trait"; }
-		}
+		public string ResearchGroup => "Trait";
 
 		/// <summary>
 		/// Traits that cannot be chosen alongside this trait.
@@ -123,7 +106,7 @@ namespace FrEee.Game.Objects.Civilization
 		/// <summary>
 		/// Parameters from the mod meta templates.
 		/// </summary>
-		public IDictionary<string, object> TemplateParameters { get; set; }
+		public IDictionary<string, object>? TemplateParameters { get; set; }
 
 		public IList<Requirement<Empire>> UnlockRequirements
 		{
@@ -143,9 +126,6 @@ namespace FrEee.Game.Objects.Civilization
 			// nothing to do
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name ?? string.Empty;
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Waypoint.cs
+++ b/FrEee/Game/Objects/Civilization/Waypoint.cs
@@ -1,10 +1,12 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Orders;
 using FrEee.Game.Objects.Space;
 using FrEee.Utility;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Civilization
 {
@@ -18,38 +20,22 @@ namespace FrEee.Game.Objects.Civilization
 			Owner = Empire.Current;
 		}
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
-		public bool IsDisposed
-		{
-			get;
-			set;
-		}
+		public bool IsDisposed { get; set; }
 
-		public bool IsMemory
-		{
-			get;
-			set;
-		}
+		public bool IsMemory { get; set; }
 
 		public abstract string Name { get; }
 
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire? Owner { get { return owner; } set { owner = value; } }
 
-		public abstract Sector Sector { get; set; }
+		public abstract Sector? Sector { get; set; }
 
-		public abstract StarSystem StarSystem { get; }
+		public abstract StarSystem? StarSystem { get; }
 
-		public double Timestamp
-		{
-			get;
-			set;
-		}
+		public double Timestamp { get; set; }
 
 		/// <summary>
 		/// Number of vehicles whose orders were altered when this waypoint was deleted.
@@ -57,7 +43,7 @@ namespace FrEee.Game.Objects.Civilization
 		[DoNotSerialize]
 		internal int AlteredQueuesOnDelete { get; private set; }
 
-		private GalaxyReference<Empire> owner { get; set; }
+		private GalaxyReference<Empire>? owner { get; set; }
 
 		/// <summary>
 		/// Only the waypoint's owner can see it.
@@ -95,7 +81,7 @@ namespace FrEee.Game.Objects.Civilization
 					if (order is WaypointOrder)
 					{
 						var wo = order as WaypointOrder;
-						if (wo.Target == this)
+						if (wo?.Target == this)
 							foundWaypoint = true;
 					}
 					if (foundWaypoint)
@@ -108,10 +94,7 @@ namespace FrEee.Game.Objects.Civilization
 			Galaxy.Current.UnassignID(this);
 		}
 
-		public bool IsObsoleteMemory(Empire emp)
-		{
-			return false;
-		}
+		public bool IsObsoleteMemory(Empire emp) => false;
 
 		public void Redact(Empire emp)
 		{
@@ -119,14 +102,11 @@ namespace FrEee.Game.Objects.Civilization
 				Dispose();
 		}
 
-		public virtual void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public virtual void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			// doesn't use client objects, nothing to do here
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name;
 	}
 }

--- a/FrEee/Game/Objects/Civilization/Waypoint.cs
+++ b/FrEee/Game/Objects/Civilization/Waypoint.cs
@@ -43,7 +43,7 @@ namespace FrEee.Game.Objects.Civilization
 		[DoNotSerialize]
 		internal int AlteredQueuesOnDelete { get; private set; }
 
-		private GalaxyReference<Empire>? owner { get; set; }
+		private GalaxyReference<Empire?>? owner { get; set; }
 
 		/// <summary>
 		/// Only the waypoint's owner can see it.

--- a/FrEee/Game/Objects/Combat/BeamWeaponDisplayEffect.cs
+++ b/FrEee/Game/Objects/Combat/BeamWeaponDisplayEffect.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using System.Drawing;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat
 {
@@ -11,29 +13,14 @@ namespace FrEee.Game.Objects.Combat
 		{
 		}
 
-		public override Point GlobalSpriteOffset
-		{
-			get { return new Point(); }
-		}
+		public override Point GlobalSpriteOffset => new Point();
 
-		public override string GlobalSpriteSheetName
-		{
-			get { return "Beams"; }
-		}
+		public override string GlobalSpriteSheetName => "Beams";
 
-		public override Point ShipsetSpriteOffset
-		{
-			get { return new Point(); }
-		}
+		public override Point ShipsetSpriteOffset => new Point();
 
-		public override string ShipsetSpriteSheetName
-		{
-			get { return "Beams"; }
-		}
+		public override string ShipsetSpriteSheetName => "Beams";
 
-		public override Size SpriteSize
-		{
-			get { return new Size(20, 20); }
-		}
+		public override Size SpriteSize => new Size(20, 20);
 	}
 }

--- a/FrEee/Game/Objects/Combat/Grid/Battle.cs
+++ b/FrEee/Game/Objects/Combat/Grid/Battle.cs
@@ -220,9 +220,9 @@ namespace FrEee.Game.Objects.Combat.Grid
 					var oldpos = locations[c];
 					if (c is Seeker s)
 					{
-						if (locations[s] == null)
+						if (locations[s] is null)
 							continue; // HACK - seeker is destroyed but still showing up in turn order
-						if (locations[s.Target] == null)
+						if (locations[s.Target] is null)
 						{
 							s.Hitpoints = 0; // seekers self destruct when their target is destroyed
 							Events.Last().Add(new CombatantDestroyedEvent(this, s, locations[s]));

--- a/FrEee/Game/Objects/Combat/Grid/BattleEvent.cs
+++ b/FrEee/Game/Objects/Combat/Grid/BattleEvent.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FrEee.Game.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {
@@ -22,12 +19,23 @@ namespace FrEee.Game.Objects.Combat.Grid
 		[DoNotCopy]
 		public IBattle Battle { get; set; }
 
-		private GalaxyReference<ICombatant> combatant { get; set; }
+		private GalaxyReference<ICombatant?>? combatant { get; set; }
 
 		[DoNotSerialize]
-		public ICombatant Combatant
+		public ICombatant? Combatant
 		{
-			get => combatant?.Value ?? Battle?.StartCombatants?[combatant.ID];
+			get
+			{
+				if (combatant?.Value != null)
+				{
+					return combatant.Value;
+				}
+				else if (combatant?.ID != null)
+				{
+					return Battle?.StartCombatants[combatant.ID];
+				}
+				return null;
+			}
 			set => combatant = value.ReferViaGalaxy();
 		}
 

--- a/FrEee/Game/Objects/Combat/Grid/CombatantAppearsEvent.cs
+++ b/FrEee/Game/Objects/Combat/Grid/CombatantAppearsEvent.cs
@@ -1,7 +1,8 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
-using System;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {
@@ -10,7 +11,7 @@ namespace FrEee.Game.Objects.Combat.Grid
 		public CombatantAppearsEvent(IBattle battle, ICombatant combatant, IntVector2 position)
 			: base(battle, combatant, position, position)
 		{
-			IsUnarmed = !(Combatant is Seeker) && !Combatant.Weapons.Any();
+			IsUnarmed = !(Combatant is Seeker) && !Combatant!.Weapons.Any();
 		}
 
 		public bool IsUnarmed { get; set; }

--- a/FrEee/Game/Objects/Combat/Grid/CombatantDestroyedEvent.cs
+++ b/FrEee/Game/Objects/Combat/Grid/CombatantDestroyedEvent.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {

--- a/FrEee/Game/Objects/Combat/Grid/CombatantDisappearsEvent.cs
+++ b/FrEee/Game/Objects/Combat/Grid/CombatantDisappearsEvent.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
 using System;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {

--- a/FrEee/Game/Objects/Combat/Grid/CombatantLaunchedEvent.cs
+++ b/FrEee/Game/Objects/Combat/Grid/CombatantLaunchedEvent.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {
@@ -12,12 +14,24 @@ namespace FrEee.Game.Objects.Combat.Grid
 			Launcher = launcher;
 		}
 
-		private GalaxyReference<ICombatant> launcher { get; set; }
+		private GalaxyReference<ICombatant?>? launcher { get; set; }
 
 		[DoNotSerialize]
-		public ICombatant Launcher
+		public ICombatant? Launcher
 		{
-			get => launcher?.Value ?? Battle?.StartCombatants?[launcher.ID];
+			get
+			{
+				if (launcher?.Value != null)
+				{
+					return launcher.Value;
+				}
+				else if (launcher?.ID != null)
+				{
+					return Battle?.StartCombatants?[launcher.ID];
+				}
+				return null;
+			}
+
 			set => launcher = value.ReferViaGalaxy();
 		}
 

--- a/FrEee/Game/Objects/Combat/Grid/CombatantMovesEvent.cs
+++ b/FrEee/Game/Objects/Combat/Grid/CombatantMovesEvent.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {

--- a/FrEee/Game/Objects/Combat/Grid/CombatantsCollideEvent.cs
+++ b/FrEee/Game/Objects/Combat/Grid/CombatantsCollideEvent.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {
@@ -21,12 +23,24 @@ namespace FrEee.Game.Objects.Combat.Grid
 		}
 
 
-		private GalaxyReference<ICombatant> target { get; set; }
+		private GalaxyReference<ICombatant?>? target { get; set; }
 
 		[DoNotSerialize]
-		public ICombatant Target
+		public ICombatant? Target
 		{
-			get => target?.Value ?? Battle?.StartCombatants?[target.ID];
+			get
+			{
+				if (target?.Value != null)
+				{
+					return target.Value;
+				}
+				else if (target?.ID != null)
+				{
+					return Battle?.StartCombatants?[target.ID];
+				}
+				return null;
+			}
+
 			set => target = value.ReferViaGalaxy();
 		}
 

--- a/FrEee/Game/Objects/Combat/Grid/Extensions.cs
+++ b/FrEee/Game/Objects/Combat/Grid/Extensions.cs
@@ -1,11 +1,12 @@
-using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 public static class Extensions
 {
     public static HashSet<T> ToHashSet<T>(
         this IEnumerable<T> source,
-        IEqualityComparer<T> comparer = null)
+        IEqualityComparer<T>? comparer = null)
     {
         return new HashSet<T>(source, comparer);
     }

--- a/FrEee/Game/Objects/Combat/Grid/GroundBattle.cs
+++ b/FrEee/Game/Objects/Combat/Grid/GroundBattle.cs
@@ -1,16 +1,16 @@
-﻿using FrEee.Game.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
-using FrEee.Game.Objects.LogMessages;
 using FrEee.Game.Objects.Space;
 using FrEee.Game.Objects.Vehicles;
 using FrEee.Modding;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {
@@ -59,7 +59,7 @@ namespace FrEee.Game.Objects.Combat.Grid
 		public override void PlaceCombatants(SafeDictionary<ICombatant, IntVector2> locations)
 		{
 			// in ground combat, for now everyone is right on top of each other
-			foreach (var c in Combatants)
+			foreach (var c in Combatants ?? new HashSet<ICombatant>())
 				locations.Add(c, new IntVector2());
 		}
 
@@ -67,7 +67,7 @@ namespace FrEee.Game.Objects.Combat.Grid
 
 		public override void ModifyHappiness()
 		{
-			foreach (var e in Empires)
+			foreach (var e in Empires ?? Enumerable.Empty<Empire>())
 			{
 				switch (this.ResultFor(e))
 				{
@@ -85,7 +85,6 @@ namespace FrEee.Game.Objects.Combat.Grid
 						}
 						break;
 				}
-
 			}
 		}
 

--- a/FrEee/Game/Objects/Combat/Grid/IBattleEvent.cs
+++ b/FrEee/Game/Objects/Combat/Grid/IBattleEvent.cs
@@ -1,12 +1,14 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {
 	public interface IBattleEvent
 	{
 		IBattle Battle { get; }
-		ICombatant Combatant { get; }
+		ICombatant? Combatant { get; }
 		IntVector2 EndPosition { get; }
 		IntVector2 StartPosition { get; }
 	}

--- a/FrEee/Game/Objects/Combat/Grid/SpaceBattle.cs
+++ b/FrEee/Game/Objects/Combat/Grid/SpaceBattle.cs
@@ -1,17 +1,17 @@
-﻿using FrEee.Game.Interfaces;
-using FrEee.Game.Objects.LogMessages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using FrEee.Game.Interfaces;
+using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Space;
 using FrEee.Modding;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
-using Microsoft.Scripting.Runtime;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Principal;
-using System.Text;
-using System.Threading.Tasks;
+
 using static System.Math;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {
@@ -39,15 +39,15 @@ namespace FrEee.Game.Objects.Combat.Grid
 		{
 			base.Initialize(combatants);
 
-			Empires = Sector.SpaceObjects.OfType<ICombatSpaceObject>().Select(sobj => sobj.Owner).Where(emp => emp != null).Distinct().ToArray();
+			Empires = Sector?.SpaceObjects.OfType<ICombatSpaceObject>().Select(sobj => sobj.Owner).Where(emp => emp != null).Distinct().ToArray();
 
-			int moduloID = (int)(Sector.StarSystem.ID % 100000);
+			int moduloID = (int)(Sector?.StarSystem.ID ?? 0 % 100000);
 			Dice = new PRNG((int)(moduloID / Galaxy.Current.Timestamp * 10));
 		}
 
 		public override void PlaceCombatants(SafeDictionary<ICombatant, IntVector2> locations)
 		{
-			if (Sector.SpaceObjects.OfType<WarpPoint>().Any())
+			if (Sector?.SpaceObjects.OfType<WarpPoint>().Any() ?? false)
 			{
 				// HACK - warp point in sector, assume someone warped
 				// TODO - do this for warp point exits instead since warp points may be one way
@@ -108,10 +108,10 @@ namespace FrEee.Game.Objects.Combat.Grid
 		{
 			get
 			{
-				if (Sector.SpaceObjects.OfType<StellarObject>().Any())
+				if (Sector?.SpaceObjects.OfType<StellarObject>().Any() ?? false)
 					return "Battle at " + Sector.SpaceObjects.OfType<StellarObject>().Largest();
-				var coords = Sector.Coordinates;
-				return "Battle at " + Sector.StarSystem + " sector (" + coords.X + ", " + coords.Y + ")";
+				var coords = Sector?.Coordinates ?? new System.Drawing.Point(0, 0);
+				return "Battle at " + Sector?.StarSystem ?? string.Empty + " sector (" + coords.X + ", " + coords.Y + ")";
 			}
 		}
 
@@ -119,7 +119,7 @@ namespace FrEee.Game.Objects.Combat.Grid
 
 		public override void ModifyHappiness()
 		{
-			foreach (var e in Empires)
+			foreach (var e in Empires ?? Enumerable.Empty<Empire>())
 			{
 				switch (this.ResultFor(e))
 				{

--- a/FrEee/Game/Objects/Combat/Grid/WeaponFiresEvent.cs
+++ b/FrEee/Game/Objects/Combat/Grid/WeaponFiresEvent.cs
@@ -1,13 +1,15 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Technology;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat.Grid
 {
 	public class WeaponFiresEvent : BattleEvent
 	{
-		public WeaponFiresEvent(Battle battle, ICombatant attacker, IntVector2 here, ICombatant target, IntVector2 there, Component weapon, Hit hit, bool wasTargetDisarmed)
+		public WeaponFiresEvent(Battle battle, ICombatant attacker, IntVector2 here, ICombatant target, IntVector2 there, Component weapon, Hit? hit, bool wasTargetDisarmed)
 			: base(battle, attacker, here, there)
 		{
 			Attacker = attacker;
@@ -20,28 +22,52 @@ namespace FrEee.Game.Objects.Combat.Grid
 		}
 		public bool IsHit { get; set; }
 
-		private GalaxyReference<ICombatant> attacker { get; set; }
+		private GalaxyReference<ICombatant?>? attacker { get; set; }
 
-		private GalaxyReference<ICombatant> target { get; set; }
+		private GalaxyReference<ICombatant?>? target { get; set; }
 
 		[DoNotSerialize]
-		public ICombatant Attacker
+		public ICombatant? Attacker
 		{
-			get => attacker?.Value ?? Battle?.StartCombatants?[attacker.ID];
+			get
+			{
+				if (attacker?.Value != null)
+				{
+					return attacker.Value;
+				}
+				else if (attacker?.ID != null)
+				{
+					return Battle?.StartCombatants?[attacker.ID];
+				}
+				return null;
+			}
+
 			set => attacker = value.ReferViaGalaxy();
 		}
 
 		[DoNotSerialize]
-		public ICombatant Target
+		public ICombatant? Target
 		{
-			get => target?.Value ?? Battle?.StartCombatants?[target.ID];
+			get
+			{
+				if (target?.Value != null)
+				{
+					return target.Value;
+				}
+				else if (target?.ID != null)
+				{
+					return Battle?.StartCombatants?[target.ID];
+				}
+				return null;
+			}
+
 			set => target = value.ReferViaGalaxy();
 		}
 
 		// TODO - make this some sort of reference?
 		public Component Weapon { get; set; }
 
-		public Hit Hit { get; set; }
+		public Hit? Hit { get; set; }
 		public int Damage { get; set; }
 
 		public bool WasTargetDisarmed { get; set; }

--- a/FrEee/Game/Objects/Combat/Hit.cs
+++ b/FrEee/Game/Objects/Combat/Hit.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FrEee.Game.Interfaces;
 using FrEee.Modding;
 using FrEee.Modding.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat
 {
@@ -17,7 +19,7 @@ namespace FrEee.Game.Objects.Combat
 			Shot = shot;
 			DamageType = shot?.DamageType ?? DamageType.Normal;
 			Target = target;
-			NominalDamage = nominalDamage ?? shot.DamageLeft;
+			NominalDamage = nominalDamage ?? shot?.DamageLeft ?? 0;
 		}
 
 		public Hit(DamageType dt, int damage, IDamageable target)
@@ -37,15 +39,15 @@ namespace FrEee.Game.Objects.Combat
 		/// <summary>
 		/// The shot which inflicted this hit.
 		/// </summary>
-		public Shot Shot { get; set; }
+		public Shot? Shot { get; set; }
 
 		/// <summary>
 		/// The specific target of this hit.
 		/// </summary>
 		[DoNotSerialize]
-		public IDamageable Target
+		public IDamageable? Target
 		{
-			get { return target?.Value ?? _target; }
+			get => target?.Value ?? _target;
 			set
 			{
 				if (value is IDamageableReferrable dr)
@@ -55,21 +57,21 @@ namespace FrEee.Game.Objects.Combat
 			}
 		}
 
-		public IDictionary<string, object> Variables
+		public IDictionary<string, object?> Variables
 		{
 			get
 			{
-				var sv = Shot.Variables;
-				var result = new SafeDictionary<string, object>();
-				foreach (var v in sv)
+				var sv = Shot?.Variables;
+				var result = new SafeDictionary<string, object?>();
+				foreach (var v in sv ?? new Dictionary<string, object?>())
 					result.Add(v);
 				result["target"] = Target;
 				return result;
 			}
 		}
 
-		private GalaxyReference<IDamageableReferrable> target { get; set; }
+		private GalaxyReference<IDamageableReferrable>? target { get; set; }
 
-		private IDamageable _target { get; set; }
+		private IDamageable? _target { get; set; }
 	}
 }

--- a/FrEee/Game/Objects/Combat/Hit.cs
+++ b/FrEee/Game/Objects/Combat/Hit.cs
@@ -14,7 +14,7 @@ namespace FrEee.Game.Objects.Combat
 	/// </summary>
 	public class Hit : IFormulaHost
 	{
-		public Hit(Shot shot, IDamageable target, int? nominalDamage = null)
+		public Hit(Shot? shot, IDamageable target, int? nominalDamage = null)
 		{
 			Shot = shot;
 			DamageType = shot?.DamageType ?? DamageType.Normal;

--- a/FrEee/Game/Objects/Combat/IBattle.cs
+++ b/FrEee/Game/Objects/Combat/IBattle.cs
@@ -1,17 +1,18 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
-using FrEee.Game.Objects.Technology;
 using FrEee.Utility;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat
 {
 	public interface IBattle : INamed, IPictorial, ILocated
 	{
-		ISet<ICombatant> Combatants { get; }
-		PRNG Dice { get; set; }
-		IEnumerable<Empire> Empires { get; }
+		ISet<ICombatant>? Combatants { get; }
+		PRNG? Dice { get; set; }
+		IEnumerable<Empire>? Empires { get; }
 		IList<LogMessage> Log { get; }
 		double Timestamp { get; }
 		IDictionary<long, ICombatant> StartCombatants { get; }

--- a/FrEee/Game/Objects/Combat/ProjectileWeaponDisplayEffect.cs
+++ b/FrEee/Game/Objects/Combat/ProjectileWeaponDisplayEffect.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using System.Drawing;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat
 {
@@ -11,29 +13,14 @@ namespace FrEee.Game.Objects.Combat
 		{
 		}
 
-		public override Point GlobalSpriteOffset
-		{
-			get { return new Point(); }
-		}
+		public override Point GlobalSpriteOffset => new Point();
 
-		public override string GlobalSpriteSheetName
-		{
-			get { return "Torps"; }
-		}
+		public override string GlobalSpriteSheetName => "Torps";
 
-		public override Point ShipsetSpriteOffset
-		{
-			get { return new Point(); }
-		}
+		public override Point ShipsetSpriteOffset => new Point();
 
-		public override string ShipsetSpriteSheetName
-		{
-			get { return "Torps"; }
-		}
+		public override string ShipsetSpriteSheetName => "Torps";
 
-		public override Size SpriteSize
-		{
-			get { return new Size(20, 20); }
-		}
+		public override Size SpriteSize => new Size(20, 20);
 	}
 }

--- a/FrEee/Game/Objects/Combat/Seeker.cs
+++ b/FrEee/Game/Objects/Combat/Seeker.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Space;
@@ -12,6 +12,8 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Combat
 {
 	/// <summary>
@@ -19,7 +21,7 @@ namespace FrEee.Game.Objects.Combat
 	/// </summary>
 	public class Seeker : ICombatant
 	{
-		public Seeker(Sector sector, Empire owner, ICombatant attacker, Component launcher, ICombatant target)
+		public Seeker(Sector? sector, Empire owner, ICombatant attacker, Component launcher, ICombatant target)
 		{
 			Sector = sector;
 			Owner = owner;
@@ -39,35 +41,24 @@ namespace FrEee.Game.Objects.Combat
 		/// <summary>
 		/// Seekers don't fire so it doesn't really matter...
 		/// </summary>
-		public int Accuracy
-		{
-			get { return 0; }
-		}
+		public int Accuracy => 0;
 
 		/// <summary>
 		/// TODO - armored seekers?
 		/// </summary>
-		public int ArmorHitpoints
-		{
-			get { return 0; }
-		}
+		public int ArmorHitpoints => 0;
 
 		/// <summary>
 		/// The battle in which this seeker was fired.
 		/// </summary>
 		[DoNotSerialize(false)]
 		[Obsolete("Seekers don't need to know what battle they're in; this property is obsolete.")]
-		public IBattle Battle { get; set; }
+		public IBattle? Battle { get; set; }
 
 		public double CombatSpeed { get; set; }
 
-		public Formula<int> Damage
-		{
-			get
-			{
-				return LaunchingComponent.Template.GetWeaponDamage(1); // TODO - seekers that do different damage based on some sort of abstracted "range"
-			}
-		}
+		// TODO - seekers that do different damage based on some sort of abstracted "range"
+		public Formula<int> Damage => LaunchingComponent.Template.GetWeaponDamage(1);
 
 		public int DistanceTraveled { get; set; }
 
@@ -75,104 +66,55 @@ namespace FrEee.Game.Objects.Combat
 		/// Seeker evasion is determined by Settings.txt.
 		/// TODO - add a field to Components.txt that lets seekers have custom evasion values?
 		/// </summary>
-		public int Evasion
-		{
-			get { return Mod.Current.Settings.SeekerEvasion; }
-		}
+		public int Evasion => Mod.Current.Settings.SeekerEvasion;
 
-		public int HitChance
-		{
-			get { return 1; }
-		}
+		public int HitChance => 1;
 
 		/// <summary>
 		/// The remaining durability of this seeker.
 		/// </summary>
 		public int Hitpoints { get; set; }
 
-		public int HullHitpoints
-		{
-			get { return Hitpoints; }
-		}
+		public int HullHitpoints => Hitpoints;
 
-		public Image Icon
-		{
-			get { return Portrait; }
-		}
+		public Image Icon => Portrait;
 
 		public Image Icon32 => Icon.Resize(32);
 
-		public IEnumerable<string> IconPaths
-		{
-			get
-			{
-				return PortraitPaths;
-			}
-		}
+		public IEnumerable<string> IconPaths => PortraitPaths;
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
 		public bool IsAlive => !IsDestroyed;
 
-		public bool IsDestroyed
-		{
-			get { return Hitpoints <= 0; }
-		}
+		public bool IsDestroyed => Hitpoints <= 0;
 
 		public bool IsDisposed { get; set; }
 
-		public bool IsMemory
-		{
-			get;
-			set;
-		}
+		public bool IsMemory { get; set; }
 
 		/// <summary>
 		/// The combatant which launched the seeker.
 		/// </summary>
-		public ICombatant LaunchingCombatant { get; private set; }
+		public ICombatant? LaunchingCombatant { get; private set; }
 
 		/// <summary>
 		/// The component which launched this seeker.
 		/// </summary>
 		public Component LaunchingComponent { get; private set; }
 
-		public int MaxArmorHitpoints
-		{
-			get { return 0; }
-		}
+		public int MaxArmorHitpoints => 0;
 
-		public int MaxHitpoints
-		{
-			get
-			{
-				return WeaponInfo.SeekerDurability; // TODO - let mounts affect seeker HP?
-			}
-		}
+		// TODO - let mounts affect seeker HP?
+		public int MaxHitpoints => WeaponInfo.SeekerDurability;
 
-		public int MaxHullHitpoints
-		{
-			get { return MaxHitpoints; }
-		}
+		public int MaxHullHitpoints => MaxHitpoints;
 
-		public int MaxNormalShields
-		{
-			get { return 0; }
-		}
+		public int MaxNormalShields => 0;
 
-		public int MaxPhasedShields
-		{
-			get { return 0; }
-		}
+		public int MaxPhasedShields => 0;
 
-		public int MaxShieldHitpoints
-		{
-			get { return MaxNormalShields + MaxPhasedShields; }
-		}
+		public int MaxShieldHitpoints => MaxNormalShields + MaxPhasedShields;
 
 		public int MaxTargets => 0;
 
@@ -187,10 +129,7 @@ namespace FrEee.Game.Objects.Combat
 		/// </summary>
 		public int NormalShields
 		{
-			get
-			{
-				return 0;
-			}
+			get => 0;
 			set
 			{
 				// do nothing
@@ -208,21 +147,14 @@ namespace FrEee.Game.Objects.Combat
 		/// </summary>
 		public int PhasedShields
 		{
-			get
-			{
-				return 0;
-			}
+			get => 0;
 			set
 			{
 				// do nothing
 			}
 		}
 
-		public Image Portrait
-		{
-			// TODO - custom seeker images per shipset
-			get { return Pictures.GetGenericImage<Seeker>(1.0); }
-		}
+		public Image Portrait => Pictures.GetGenericImage<Seeker>(1.0);
 
 		public IEnumerable<string> PortraitPaths
 		{
@@ -234,29 +166,20 @@ namespace FrEee.Game.Objects.Combat
 
 				if (Mod.Current?.RootPath != null)
 				{
-					paths.Add(Path.Combine("Mods", Mod.Current.RootPath, "Pictures", "Races", shipsetPath, "Seeker"));
-					paths.Add(Path.Combine("Mods", Mod.Current.RootPath, "Pictures", "Races", shipsetPath, shipsetPath + "_" + "Seeker"));
+					paths.Add(Path.Combine("Mods", Mod.Current.RootPath, "Pictures", "Races", shipsetPath ?? string.Empty, "Seeker"));
+					paths.Add(Path.Combine("Mods", Mod.Current.RootPath, "Pictures", "Races", shipsetPath ?? string.Empty, shipsetPath + "_" + "Seeker"));
 				}
-				paths.Add(Path.Combine("Pictures", "Races", shipsetPath, "Seeker"));
-				paths.Add(Path.Combine("Pictures", "Races", shipsetPath, shipsetPath + "_" + "Seeker"));
+				paths.Add(Path.Combine("Pictures", "Races", shipsetPath ?? string.Empty, "Seeker"));
+				paths.Add(Path.Combine("Pictures", "Races", shipsetPath ?? string.Empty, shipsetPath + "_" + "Seeker"));
 				return paths;
 			}
 		}
 
-		public Sector Sector
-		{
-			get; set;
-		}
+		public Sector? Sector { get; set; }
 
-		public int ShieldHitpoints
-		{
-			get { return NormalShields + PhasedShields; }
-		}
+		public int ShieldHitpoints => NormalShields + PhasedShields;
 
-		public StarSystem StarSystem
-		{
-			get { return Sector.StarSystem; }
-		}
+		public StarSystem? StarSystem => Sector?.StarSystem;
 
 		/// <summary>
 		/// The target of the seeker.
@@ -265,35 +188,23 @@ namespace FrEee.Game.Objects.Combat
 
 		public double Timestamp { get; set; }
 
-		public SeekingWeaponInfo WeaponInfo
-		{
-			get { return (SeekingWeaponInfo)LaunchingComponent.Template.ComponentTemplate.WeaponInfo; }
-		}
+		public SeekingWeaponInfo WeaponInfo => (SeekingWeaponInfo)LaunchingComponent.Template.ComponentTemplate.WeaponInfo;
 
 		/// <summary>
 		/// Seekers do not carry other weapons.
 		/// </summary>
-		public IEnumerable<Component> Weapons
-		{
-			get { return Enumerable.Empty<Component>(); }
-		}
+		public IEnumerable<Component> Weapons => Enumerable.Empty<Component>();
 
-		public WeaponTargets WeaponTargetType
-		{
-			get { return WeaponTargets.Seeker; }
-		}
+		public WeaponTargets WeaponTargetType => WeaponTargets.Seeker;
 
-		public bool CanTarget(ITargetable target)
-		{
-			return target != null && LaunchingComponent.Template.ComponentTemplate.WeaponInfo.Targets.HasFlag(target.WeaponTargetType);
-		}
+		public bool CanTarget(ITargetable target) => target != null && LaunchingComponent.Template.ComponentTemplate.WeaponInfo.Targets.HasFlag(target.WeaponTargetType);
 
 		public Visibility CheckVisibility(Empire emp)
 		{
 			if (Owner == emp)
 				return Visibility.Owned;
 			if (Galaxy.Current.Battles.Any(b =>
-				(b.Combatants.Contains(this)
+				(b.Combatants?.Contains(this) ?? false
 					|| b.StartCombatants.Values.Contains(this)
 					|| b.EndCombatants.Values.Contains(this))
 				&& b.Combatants.Any(c => c.Owner == emp)))
@@ -305,19 +216,12 @@ namespace FrEee.Game.Objects.Combat
 		{
 			if (IsDisposed)
 				return;
-			Target = null;
 			Galaxy.Current.UnassignID(this);
 		}
 
-		public bool IsHostileTo(Empire emp)
-		{
-			return Owner == null ? false : Owner.IsEnemyOf(emp, StarSystem);
-		}
+		public bool IsHostileTo(Empire emp) => Owner != null && Owner.IsEnemyOf(emp, StarSystem);
 
-		public bool IsObsoleteMemory(Empire emp)
-		{
-			return Timestamp < Galaxy.Current.Timestamp - 1;
-		}
+		public bool IsObsoleteMemory(Empire emp) => Timestamp < Galaxy.Current.Timestamp - 1;
 
 		public void Redact(Empire emp)
 		{
@@ -346,21 +250,16 @@ namespace FrEee.Game.Objects.Combat
 			// do nothing, seekers don't have shields
 		}
 
-		public int TakeDamage(Hit hit, PRNG dice = null)
+		public int TakeDamage(Hit hit, PRNG? dice = null)
 		{
-			var damage = hit.Shot.DamageLeft;
-			damage *= hit.Shot.DamageType.SeekerDamage.Evaluate(this) / 100;
-			var pierced = damage * hit.Shot.DamageType.ComponentPiercing.Evaluate(this);
-			int realDamage;
-			realDamage = Math.Min(Hitpoints, damage);
+			var damage = hit.Shot?.DamageLeft ?? 0;
+			damage *= hit.Shot?.DamageType.SeekerDamage.Evaluate(this) ?? 0 / 100;
+			var realDamage = Math.Min(Hitpoints, damage);
 			Hitpoints -= realDamage;
 			return damage - realDamage;
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name;
 
 		public IEnumerable<Component> Components => Enumerable.Empty<Component>();
 

--- a/FrEee/Game/Objects/Combat/SeekerWeaponDisplayEffect.cs
+++ b/FrEee/Game/Objects/Combat/SeekerWeaponDisplayEffect.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using System.Drawing;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat
 {
@@ -11,29 +13,14 @@ namespace FrEee.Game.Objects.Combat
 		{
 		}
 
-		public override Point GlobalSpriteOffset
-		{
-			get { return new Point(); }
-		}
+		public override Point GlobalSpriteOffset => new Point();
 
-		public override string GlobalSpriteSheetName
-		{
-			get { return "Seekers"; }
-		}
+		public override string GlobalSpriteSheetName => "Seekers";
 
-		public override Point ShipsetSpriteOffset
-		{
-			get { return new Point(40, 0); }
-		}
+		public override Point ShipsetSpriteOffset => new Point(40, 0);
 
-		public override string ShipsetSpriteSheetName
-		{
-			get { return "Main"; }
-		}
+		public override string ShipsetSpriteSheetName => "Main";
 
-		public override Size SpriteSize
-		{
-			get { return new Size(20, 20); }
-		}
+		public override Size SpriteSize => new Size(20, 20);
 	}
 }

--- a/FrEee/Game/Objects/Combat/Shot.cs
+++ b/FrEee/Game/Objects/Combat/Shot.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Technology;
 using FrEee.Modding;
 using FrEee.Modding.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat
 {
@@ -13,7 +15,7 @@ namespace FrEee.Game.Objects.Combat
 	/// </summary>
 	public class Shot : IFormulaHost
 	{
-		public Shot(ICombatant attacker, Component weapon, IDamageable defender, int range)
+		public Shot(ICombatant? attacker, Component weapon, IDamageable defender, int range)
 		{
 			Attacker = attacker;
 			Weapon = weapon;
@@ -22,10 +24,10 @@ namespace FrEee.Game.Objects.Combat
 			DamageLeft = FullDamage;
 		}
 
-		public GalaxyReference<ICombatant> attacker { get; set; }
+		public GalaxyReference<ICombatant>? attacker { get; set; }
 
 		[DoNotSerialize]
-		public ICombatant Attacker { get { return attacker == null ? null : attacker.Value; } set { attacker = value == null ? null : value.ReferViaGalaxy(); } }
+		public ICombatant? Attacker { get { return attacker == null ? null : attacker.Value; } set { attacker = value == null ? null : value.ReferViaGalaxy(); } }
 
 		public int DamageLeft { get; private set; }
 
@@ -43,9 +45,9 @@ namespace FrEee.Game.Objects.Combat
 		/// The specific target of this hit.
 		/// </summary>
 		[DoNotSerialize]
-		public IDamageable Defender
+		public IDamageable? Defender
 		{
-			get { return target?.Value ?? _target; }
+			get => target?.Value ?? _target;
 			set
 			{
 				if (value is IDamageableReferrable dr)
@@ -79,35 +81,26 @@ namespace FrEee.Game.Objects.Combat
 			}
 		}
 
-		public IEnumerable<Hit> Hits { get; private set; }
+		public IEnumerable<Hit>? Hits { get; private set; }
 		public int Range { get; set; }
-		public GalaxyReference<IDamageableReferrable> target { get; set; }
-		private IDamageable _target { get; set; }
+		public GalaxyReference<IDamageableReferrable>? target { get; set; }
+		private IDamageable? _target { get; set; }
 
-		public IDictionary<string, object> Variables
-		{
-			get
-			{
-				return new Dictionary<string, object>
-				{
-					{ "range", Range},
-				};
-			}
-		}
+		public IDictionary<string, object?> Variables => new Dictionary<string, object?> { { "range", Range } };
 
 		// TODO - make this some sort of reference?
 		public Component Weapon { get; set; }
 
-		public int InflictDamage(IDamageable target, PRNG dice = null)
+		public int InflictDamage(IDamageable target, PRNG? dice = null)
 		{
 			var hit = new Hit(this, target, DamageLeft);
 			DamageLeft = target.TakeDamage(hit, dice);
 			return DamageLeft;
 		}
 
-		public bool RollAccuracy(PRNG dice = null)
+		public bool RollAccuracy(PRNG? dice = null)
 		{
-			var accuracy = Weapon.Template.WeaponAccuracy + Attacker.Accuracy + Mod.Current.Settings.WeaponAccuracyPointBlank - Range * Mod.Current.Settings.WeaponAccuracyLossPerSquare;
+			var accuracy = Weapon.Template.WeaponAccuracy + Attacker?.Accuracy + Mod.Current.Settings.WeaponAccuracyPointBlank - Range * Mod.Current.Settings.WeaponAccuracyLossPerSquare;
 			int evasion = 0;
 			if (Defender is ITargetable t)
 				evasion = t.Evasion;
@@ -119,9 +112,6 @@ namespace FrEee.Game.Objects.Combat
 			return RandomHelper.Range(0, 99, dice) < netAccuracy;
 		}
 
-		public override string ToString()
-		{
-			return Attacker + "'s " + Weapon + " vs. " + Defender + " at range " + Range + " (" + DamageLeft + " damage left)";
-		}
+		public override string ToString() => $"{Attacker}'s {Weapon} vs. {Defender} at range {Range} ({DamageLeft} damage left)";
 	}
 }

--- a/FrEee/Game/Objects/Combat/Shot.cs
+++ b/FrEee/Game/Objects/Combat/Shot.cs
@@ -15,7 +15,7 @@ namespace FrEee.Game.Objects.Combat
 	/// </summary>
 	public class Shot : IFormulaHost
 	{
-		public Shot(ICombatant? attacker, Component weapon, IDamageable defender, int range)
+		public Shot(ICombatant? attacker, Component? weapon, IDamageable defender, int range)
 		{
 			Attacker = attacker;
 			Weapon = weapon;
@@ -64,7 +64,7 @@ namespace FrEee.Game.Objects.Combat
 		{
 			get
 			{
-				var r = Range - (Weapon.Template.Mount == null ? 0 : Weapon.Template.Mount.WeaponRangeModifier.Evaluate(Weapon));
+				var r = Range - (Weapon?.Template.Mount == null ? 0 : Weapon.Template.Mount.WeaponRangeModifier.Evaluate(Weapon));
 				if (r < 1)
 					return 1;
 				return r;
@@ -89,7 +89,7 @@ namespace FrEee.Game.Objects.Combat
 		public IDictionary<string, object?> Variables => new Dictionary<string, object?> { { "range", Range } };
 
 		// TODO - make this some sort of reference?
-		public Component Weapon { get; set; }
+		public Component? Weapon { get; set; }
 
 		public int InflictDamage(IDamageable target, PRNG? dice = null)
 		{
@@ -100,7 +100,7 @@ namespace FrEee.Game.Objects.Combat
 
 		public bool RollAccuracy(PRNG? dice = null)
 		{
-			var accuracy = Weapon.Template.WeaponAccuracy + Attacker?.Accuracy + Mod.Current.Settings.WeaponAccuracyPointBlank - Range * Mod.Current.Settings.WeaponAccuracyLossPerSquare;
+			var accuracy = Weapon?.Template.WeaponAccuracy + Attacker?.Accuracy + Mod.Current.Settings.WeaponAccuracyPointBlank - Range * Mod.Current.Settings.WeaponAccuracyLossPerSquare;
 			int evasion = 0;
 			if (Defender is ITargetable t)
 				evasion = t.Evasion;

--- a/FrEee/Game/Objects/Combat/WeaponDisplayEffect.cs
+++ b/FrEee/Game/Objects/Combat/WeaponDisplayEffect.cs
@@ -1,10 +1,12 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Combat
 {
@@ -14,33 +16,21 @@ namespace FrEee.Game.Objects.Combat
 	[Serializable]
 	public abstract class WeaponDisplayEffect : IPictorial
 	{
-		protected WeaponDisplayEffect(string name)
-		{
-			Name = name;
-		}
+		protected WeaponDisplayEffect(string name) => Name = name;
 
 		/// <summary>
 		/// The pixel offset to the first sprite in the global sprite sheet.
 		/// </summary>
 		public abstract Point GlobalSpriteOffset { get; }
 
-		public Image GlobalSpriteSheet
-		{
-			get
-			{
-				return Pictures.GetModImage(Path.Combine("Pictures", "Combat", GlobalSpriteSheetName));
-			}
-		}
+		public Image GlobalSpriteSheet => Pictures.GetModImage(Path.Combine("Pictures", "Combat", GlobalSpriteSheetName));
 
 		/// <summary>
 		/// The name of the sprite sheet to use.
 		/// </summary>
 		public abstract string GlobalSpriteSheetName { get; }
 
-		public Image Icon
-		{
-			get { return GetIcon(null); }
-		}
+		public Image Icon => GetIcon(null);
 
 		public Image Icon32 => Icon.Resize(32);
 
@@ -59,18 +49,9 @@ namespace FrEee.Game.Objects.Combat
 		/// </summary>
 		public string Name { get; set; }
 
-		public Image Portrait
-		{
-			get { return Icon; }
-		}
+		public Image Portrait => Icon;
 
-		public IEnumerable<string> PortraitPaths
-		{
-			get
-			{
-				return IconPaths;
-			}
-		}
+		public IEnumerable<string> PortraitPaths => IconPaths;
 
 		/// <summary>
 		/// The pixel offset to the first sprite in the shipset-specific sprite sheet.
@@ -87,11 +68,10 @@ namespace FrEee.Game.Objects.Combat
 		/// </summary>
 		public abstract Size SpriteSize { get; }
 
-		public Image GetIcon(string shipset)
+		public Image GetIcon(string? shipset)
 		{
 			// see if we have a positive number to use a sprite sheet
-			int index = 0;
-			int.TryParse(Name, out index);
+			int.TryParse(Name, out var index);
 
 			if (index > 0)
 			{
@@ -115,8 +95,8 @@ namespace FrEee.Game.Objects.Combat
 				{
 					// no sprite sheets found
 					return Pictures.GetModImage(
-						Path.Combine("Pictures", "Races", shipset, Name),
-						Path.Combine("Pictures", "Races", shipset, shipset + "_" + Name),
+						Path.Combine("Pictures", "Races", shipset ?? string.Empty, Name),
+						Path.Combine("Pictures", "Races", shipset ?? string.Empty, shipset + "_" + Name),
 						Path.Combine("Pictures", "Combat", Name));
 				}
 
@@ -132,15 +112,12 @@ namespace FrEee.Game.Objects.Combat
 			{
 				// use individual sprites
 				return Pictures.GetModImage(
-					Path.Combine("Pictures", "Races", shipset, Name),
-					Path.Combine("Pictures", "Races", shipset, shipset + "_" + Name),
+					Path.Combine("Pictures", "Races", shipset ?? string.Empty, Name),
+					Path.Combine("Pictures", "Races", shipset ?? string.Empty, shipset + "_" + Name),
 					Path.Combine("Pictures", "Combat", Name));
 			}
 		}
 
-		public Image LoadShipsetSpriteSheet(string shipset)
-		{
-			return Pictures.GetModImage(Path.Combine("Pictures", "Races", shipset, ShipsetSpriteSheetName));
-		}
+		public Image LoadShipsetSpriteSheet(string? shipset) => Pictures.GetModImage(Path.Combine("Pictures", "Races", shipset ?? string.Empty, ShipsetSpriteSheetName));
 	}
 }

--- a/FrEee/Game/Objects/Commands/AddOrderCommand.cs
+++ b/FrEee/Game/Objects/Commands/AddOrderCommand.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.LogMessages;
 using FrEee.Game.Objects.Space;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -18,7 +20,7 @@ namespace FrEee.Game.Objects.Commands
 		{
 		}
 
-		public override IEnumerable<IReferrable> NewReferrables
+		public override IEnumerable<IReferrable?> NewReferrables
 		{
 			get
 			{
@@ -26,12 +28,9 @@ namespace FrEee.Game.Objects.Commands
 			}
 		}
 
-		public override IOrder Order
+		public override IOrder? Order
 		{
-			get
-			{
-				return NewOrder;
-			}
+			get => NewOrder;
 			set
 			{
 				base.Order = value;
@@ -39,16 +38,12 @@ namespace FrEee.Game.Objects.Commands
 			}
 		}
 
-		private IOrder NewOrder
-		{
-			get;
-			set;
-		}
+		private IOrder? NewOrder { get; set; }
 
 		public override void Execute()
 		{
 			if (Executor == null)
-				Issuer.Log.Add(new GenericLogMessage("Attempted to add an order to nonexistent object with ID=" + executor.ID + ". This is probably a game bug."));
+				Issuer?.Log.Add(new GenericLogMessage("Attempted to add an order to nonexistent object with ID=" + executor?.ID + ". This is probably a game bug."));
 			else if (Issuer == Executor.Owner)
 			{
 				if (Order is IConstructionOrder && ((IConstructionOrder)Order).Item != null)
@@ -59,10 +54,10 @@ namespace FrEee.Game.Objects.Commands
 					Executor.AddOrder(Order);
 			}
 			else
-				Issuer.Log.Add(new GenericLogMessage(Issuer + " cannot issue commands to " + Executor + " belonging to " + Executor.Owner + "!", Galaxy.Current.TurnNumber));
+				Issuer?.Log.Add(new GenericLogMessage(Issuer + " cannot issue commands to " + Executor + " belonging to " + Executor.Owner + "!", Galaxy.Current.TurnNumber));
 		}
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();
@@ -70,7 +65,7 @@ namespace FrEee.Game.Objects.Commands
 			{
 				done.Add(this);
 				base.ReplaceClientIDs(idmap, done);
-				NewOrder.ReplaceClientIDs(idmap, done);
+				NewOrder?.ReplaceClientIDs(idmap, done);
 			}
 		}
 	}

--- a/FrEee/Game/Objects/Commands/ClearPlayerNoteCommand.cs
+++ b/FrEee/Game/Objects/Commands/ClearPlayerNoteCommand.cs
@@ -1,8 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using System.Collections.Generic;
+
 using FrEee.Game.Objects.Civilization;
 using FrEee.Utility;
-using FrEee.Utility.Extensions;
-using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -16,12 +17,12 @@ namespace FrEee.Game.Objects.Commands
 		{
 		}
 
-		public SafeDictionary<string, ICollection<string>> EnabledMinisters { get; set; }
+		public SafeDictionary<string, ICollection<string>>? EnabledMinisters { get; set; }
 
 		public override void Execute()
 		{
-			if (Executor.AI == null)
-				Executor.RecordLog(Executor, $"Could not toggle AI ministers for {Executor} because there is no AI for this empire.", LogMessages.LogMessageType.Error);
+			if (Executor?.AI == null)
+				Executor?.RecordLog(Executor, $"Could not toggle AI ministers for {Executor} because there is no AI for this empire.", LogMessages.LogMessageType.Error);
 			else
 				Executor.EnabledMinisters = EnabledMinisters;
 		}

--- a/FrEee/Game/Objects/Commands/ClearPrivateNameCommand.cs
+++ b/FrEee/Game/Objects/Commands/ClearPrivateNameCommand.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -20,13 +22,15 @@ namespace FrEee.Game.Objects.Commands
 		/// What are we clearing the name on?
 		/// </summary>
 		[DoNotSerialize]
-		public INameable Target { get { return target.Value; } set { target = value.ReferViaGalaxy(); } }
+		public INameable? Target { get => target?.Value; set => target = value.ReferViaGalaxy(); }
 
-		private GalaxyReference<INameable> target { get; set; }
+		private GalaxyReference<INameable?>? target { get; set; }
 
 		public override void Execute()
 		{
-			Executor.PrivateNames.Remove(target);
+			if (target is null)
+				return;
+			Executor?.PrivateNames.Remove(target);
 		}
 	}
 }

--- a/FrEee/Game/Objects/Commands/Command.cs
+++ b/FrEee/Game/Objects/Commands/Command.cs
@@ -1,9 +1,11 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -12,29 +14,25 @@ namespace FrEee.Game.Objects.Commands
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
 	[Serializable]
-	public abstract class Command<T> : ICommand<T>
-		where T : IReferrable
+	public abstract class Command<T> : ICommand<T> where T : class, IReferrable
 	{
-		protected Command(T target)
+		protected Command(T? target)
 		{
 			Issuer = Empire.Current;
 			Executor = target;
 		}
 
 		[DoNotSerialize]
-		public T Executor { get { return executor; } set { executor = value; } }
+		public T? Executor { get => executor; set => executor = value; }
 
-		IReferrable ICommand.Executor
-		{
-			get { return Executor; }
-		}
+		IReferrable? ICommand.Executor => Executor;
 
-		public long ExecutorID { get { return executor.ID; } }
+		public long? ExecutorID => executor?.ID;
 
 		public bool IsDisposed { get; set; }
 
 		[DoNotSerialize]
-		public Empire Issuer { get { return issuer; } set { issuer = value; } }
+		public Empire? Issuer { get => issuer; set => issuer = value; }
 
 		public virtual IEnumerable<IReferrable> NewReferrables
 		{
@@ -44,21 +42,21 @@ namespace FrEee.Game.Objects.Commands
 			}
 		}
 
-		protected GalaxyReference<T> executor { get; set; }
+		protected GalaxyReference<T?>? executor { get; set; }
 
-		private GalaxyReference<Empire> issuer { get; set; }
+		private GalaxyReference<Empire?>? issuer { get; set; }
 
 		public abstract void Execute();
 
-		public virtual void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public virtual void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();
 			if (!done.Contains(this))
 			{
 				done.Add(this);
-				issuer.ReplaceClientIDs(idmap, done);
-				executor.ReplaceClientIDs(idmap, done);
+				issuer?.ReplaceClientIDs(idmap, done);
+				executor?.ReplaceClientIDs(idmap, done);
 				foreach (var r in NewReferrables.OfType<IPromotable>())
 					r.ReplaceClientIDs(idmap, done);
 			}

--- a/FrEee/Game/Objects/Commands/Command.cs
+++ b/FrEee/Game/Objects/Commands/Command.cs
@@ -34,7 +34,7 @@ namespace FrEee.Game.Objects.Commands
 		[DoNotSerialize]
 		public Empire? Issuer { get => issuer; set => issuer = value; }
 
-		public virtual IEnumerable<IReferrable> NewReferrables
+		public virtual IEnumerable<IReferrable?> NewReferrables
 		{
 			get
 			{

--- a/FrEee/Game/Objects/Commands/CreateDesignCommand.cs
+++ b/FrEee/Game/Objects/Commands/CreateDesignCommand.cs
@@ -1,9 +1,11 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -35,8 +37,8 @@ namespace FrEee.Game.Objects.Commands
 		{
 			Design.VehiclesBuilt = 0; // in case it was tested in the simulator
 			if (Design.Warnings.Any())
-				Issuer.Log.Add(Design.CreateLogMessage("The " + Design.Name + " " + Design.VehicleTypeName + " design cannot be saved because it has warnings.", LogMessages.LogMessageType.Warning));
-			Issuer.KnownDesigns.Add(Design);
+				Issuer?.Log.Add(Design.CreateLogMessage("The " + Design.Name + " " + Design.VehicleTypeName + " design cannot be saved because it has warnings.", LogMessages.LogMessageType.Warning));
+			Issuer?.KnownDesigns.Add(Design);
 		}
 	}
 }

--- a/FrEee/Game/Objects/Commands/CreateFleetCommand.cs
+++ b/FrEee/Game/Objects/Commands/CreateFleetCommand.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Space;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -48,7 +50,7 @@ namespace FrEee.Game.Objects.Commands
 			Galaxy.Current.AssignID(Fleet);
 		}
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();

--- a/FrEee/Game/Objects/Commands/CreateWaypointCommand.cs
+++ b/FrEee/Game/Objects/Commands/CreateWaypointCommand.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -20,7 +22,7 @@ namespace FrEee.Game.Objects.Commands
 		/// </summary>
 		public int? Hotkey { get; private set; }
 
-		public override IEnumerable<IReferrable> NewReferrables
+		public override IEnumerable<IReferrable?> NewReferrables
 		{
 			get
 			{
@@ -37,7 +39,7 @@ namespace FrEee.Game.Objects.Commands
 
 		public override void Execute()
 		{
-			if (!Executor.Waypoints.Contains(Waypoint))
+			if (Executor != null && !Executor.Waypoints.Contains(Waypoint))
 				Executor.Waypoints.Add(Waypoint); // add new waypoint
 		}
 	}

--- a/FrEee/Game/Objects/Commands/DeleteMessageCommand.cs
+++ b/FrEee/Game/Objects/Commands/DeleteMessageCommand.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -13,18 +15,16 @@ namespace FrEee.Game.Objects.Commands
 	{
 		public DeleteMessageCommand(IMessage msg)
 			: base(Empire.Current)
-		{
-			Message = msg;
-		}
+			=> Message = msg;
 
-		public IMessage Message { get { return message.Value; } set { message = value.ReferViaGalaxy(); } }
+		public IMessage? Message { get => message?.Value; set => message = value.ReferViaGalaxy(); }
 
-		private GalaxyReference<IMessage> message { get; set; }
+		private GalaxyReference<IMessage?>? message { get; set; }
 
 		public override void Execute()
 		{
-			Executor.IncomingMessages.Remove(Message);
-			Executor.SentMessages.Remove(Message);
+			Executor?.IncomingMessages.Remove(Message);
+			Executor?.SentMessages.Remove(Message);
 		}
 	}
 }

--- a/FrEee/Game/Objects/Commands/DeleteWaypointCommand.cs
+++ b/FrEee/Game/Objects/Commands/DeleteWaypointCommand.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Game.Objects.Civilization;
+using FrEee.Game.Objects.Civilization;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -16,16 +18,16 @@ namespace FrEee.Game.Objects.Commands
 		public override void Execute()
 		{
 			// sanity check
-			var emp = Executor.Owner;
+			var emp = Executor?.Owner;
 			if (emp != Issuer)
 			{
-				Issuer.Log.Add(Issuer.CreateLogMessage("We cannot issue a command to delete another empire's waypoints!", LogMessages.LogMessageType.Error));
+				Issuer?.Log.Add(Issuer.CreateLogMessage("We cannot issue a command to delete another empire's waypoints!", LogMessages.LogMessageType.Error));
 				return;
 			}
 
-			Executor.Dispose();
+			Executor?.Dispose();
 
-			Issuer.Log.Add(Issuer.CreateLogMessage(Executor.AlteredQueuesOnDelete + " vehicles' orders were truncated when " + Executor + " was deleted.", LogMessages.LogMessageType.Warning));
+			Issuer?.Log.Add(Issuer.CreateLogMessage(Executor?.AlteredQueuesOnDelete + " vehicles' orders were truncated when " + Executor + " was deleted.", LogMessages.LogMessageType.Warning));
 		}
 	}
 }

--- a/FrEee/Game/Objects/Commands/DisbandFleetCommand.cs
+++ b/FrEee/Game/Objects/Commands/DisbandFleetCommand.cs
@@ -1,5 +1,10 @@
-﻿using FrEee.Game.Objects.Space;
+using FrEee.Game.Interfaces;
+using FrEee.Game.Objects.Space;
+
+using System;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -15,13 +20,13 @@ namespace FrEee.Game.Objects.Commands
 
 		public override void Execute()
 		{
-			foreach (var v in Executor.Vehicles.ToArray())
+			foreach (var v in Executor?.Vehicles.ToArray() ?? Array.Empty<IMobileSpaceObject>())
 			{
-				Executor.Vehicles.Remove(v);
+				Executor?.Vehicles.Remove(v);
 				v.Container = null;
-				Executor.Sector.Place(v);
+				Executor?.Sector.Place(v);
 			}
-			Executor.Dispose();
+			Executor?.Dispose();
 		}
 	}
 }

--- a/FrEee/Game/Objects/Commands/HotkeyWaypointCommand.cs
+++ b/FrEee/Game/Objects/Commands/HotkeyWaypointCommand.cs
@@ -61,7 +61,7 @@ namespace FrEee.Game.Objects.Commands
 						if (order is WaypointOrder)
 						{
 							var wo = order as WaypointOrder;
-							if (wo?.Target == oldWaypoint && wo?.Target != null)
+							if (wo?.Target == oldWaypoint && wo?.Target != null && Executor != null)
 							{
 								wo.Target = Executor;
 								found = true;

--- a/FrEee/Game/Objects/Commands/HotkeyWaypointCommand.cs
+++ b/FrEee/Game/Objects/Commands/HotkeyWaypointCommand.cs
@@ -1,9 +1,11 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Orders;
 using FrEee.Game.Objects.Space;
 using FrEee.Utility.Extensions;
 using System;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -34,16 +36,17 @@ namespace FrEee.Game.Objects.Commands
 		public override void Execute()
 		{
 			// sanity check
-			var emp = Executor.Owner;
+			var emp = Executor?.Owner;
 			if (emp != Issuer)
 			{
-				Issuer.Log.Add(Issuer.CreateLogMessage("We cannot issue a command to hotkey another empire's waypoints!", LogMessages.LogMessageType.Error));
+				Issuer?.Log.Add(Issuer.CreateLogMessage("We cannot issue a command to hotkey another empire's waypoints!", LogMessages.LogMessageType.Error));
 				return;
 			}
 
 			// replace old waypoint
-			var oldWaypoint = emp.NumberedWaypoints[Hotkey];
-			emp.NumberedWaypoints[Hotkey] = Executor;
+			var oldWaypoint = emp?.NumberedWaypoints[Hotkey];
+			if (emp?.NumberedWaypoints != null)
+				emp.NumberedWaypoints[Hotkey] = Executor;
 
 			if (Redirect)
 			{
@@ -58,7 +61,7 @@ namespace FrEee.Game.Objects.Commands
 						if (order is WaypointOrder)
 						{
 							var wo = order as WaypointOrder;
-							if (wo.Target == oldWaypoint)
+							if (wo?.Target == oldWaypoint && wo?.Target != null)
 							{
 								wo.Target = Executor;
 								found = true;
@@ -70,7 +73,7 @@ namespace FrEee.Game.Objects.Commands
 				}
 
 				if (count > 0)
-					emp.Log.Add(Issuer.CreateLogMessage(count + " vehicles were redirected from " + oldWaypoint + " to " + Executor + ".", LogMessages.LogMessageType.Generic));
+					emp?.Log.Add(Issuer.CreateLogMessage(count + " vehicles were redirected from " + oldWaypoint + " to " + Executor + ".", LogMessages.LogMessageType.Generic));
 			}
 		}
 	}

--- a/FrEee/Game/Objects/Commands/LeaveFleetCommand.cs
+++ b/FrEee/Game/Objects/Commands/LeaveFleetCommand.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -16,8 +18,8 @@ namespace FrEee.Game.Objects.Commands
 		public override void Execute()
 		{
 			// validation
-			if (Executor.Container == null)
-				Issuer.Log.Add(Executor.CreateLogMessage(Executor + " cannot leave its fleet because it is not currently in a fleet.", LogMessages.LogMessageType.Error));
+			if (Executor?.Container == null)
+				Issuer?.Log.Add(Executor.CreateLogMessage(Executor + " cannot leave its fleet because it is not currently in a fleet.", LogMessages.LogMessageType.Error));
 			else
 			{
 				// remove from fleet

--- a/FrEee/Game/Objects/Commands/MinisterToggleCommand.cs
+++ b/FrEee/Game/Objects/Commands/MinisterToggleCommand.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -17,13 +19,15 @@ namespace FrEee.Game.Objects.Commands
 		}
 
 		[DoNotSerialize]
-		public IReferrable Target { get { return target.Value; } set { target = value.ReferViaGalaxy(); } }
+		public IReferrable? Target { get => target?.Value; set => target = value.ReferViaGalaxy(); }
 
-		private GalaxyReference<IReferrable> target { get; set; }
+		private GalaxyReference<IReferrable?>? target { get; set; }
 
 		public override void Execute()
 		{
-			Executor.PlayerNotes.Remove(target);
+			if (target is null)
+				return;
+			Executor?.PlayerNotes.Remove(target);
 		}
 	}
 }

--- a/FrEee/Game/Objects/Commands/OrderCommand.cs
+++ b/FrEee/Game/Objects/Commands/OrderCommand.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -21,21 +23,15 @@ namespace FrEee.Game.Objects.Commands
 		}
 
 		[DoNotSerialize]
-		public virtual IOrder Order
+		public virtual IOrder? Order
 		{
-			get
-			{
-				return order.Value;
-			}
-			set
-			{
-				order = value.ReferViaGalaxy();
-			}
+			get => order?.Value;
+			set => order = value.ReferViaGalaxy();
 		}
 
-		private GalaxyReference<IOrder> order { get; set; }
+		private GalaxyReference<IOrder?>? order { get; set; }
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();
@@ -43,7 +39,7 @@ namespace FrEee.Game.Objects.Commands
 			{
 				done.Add(this);
 				base.ReplaceClientIDs(idmap, done);
-				order.ReplaceClientIDs(idmap, done);
+				order?.ReplaceClientIDs(idmap, done);
 			}
 		}
 	}

--- a/FrEee/Game/Objects/Commands/RearrangeOrdersCommand.cs
+++ b/FrEee/Game/Objects/Commands/RearrangeOrdersCommand.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.LogMessages;
 using FrEee.Game.Objects.Space;
 using System;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -22,21 +24,17 @@ namespace FrEee.Game.Objects.Commands
 		/// <summary>
 		/// How many spaces up (if negative) or down (if positive) to move the order.
 		/// </summary>
-		public int DeltaPosition
-		{
-			get;
-			set;
-		}
+		public int DeltaPosition { get; set; }
 
 		public override void Execute()
 		{
-			if (Issuer == Executor.Owner)
+			if (Issuer == Executor?.Owner)
 			{
-				Executor.RearrangeOrder(Order, DeltaPosition);
+				Executor?.RearrangeOrder(Order, DeltaPosition);
 			}
 			else
 			{
-				Issuer.Log.Add(new GenericLogMessage(Issuer + " cannot issue commands to " + Executor + " belonging to " + Executor.Owner + "!", Galaxy.Current.TurnNumber));
+				Issuer?.Log.Add(new GenericLogMessage(Issuer + " cannot issue commands to " + Executor + " belonging to " + Executor?.Owner + "!", Galaxy.Current.TurnNumber));
 			}
 		}
 	}

--- a/FrEee/Game/Objects/Commands/RemoveOrderCommand.cs
+++ b/FrEee/Game/Objects/Commands/RemoveOrderCommand.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.LogMessages;
 using FrEee.Game.Objects.Space;
 using FrEee.Utility.Extensions;
 using System;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -21,18 +23,18 @@ namespace FrEee.Game.Objects.Commands
 		public override void Execute()
 		{
 			if (Order == null)
-				Issuer.Log.Add(new GenericLogMessage("The server attempted to remove a null order from " + Executor + ". Perhaps this order was not actually on the server yet; it was just added and removed this past turn. This is probably a game bug."));
+				Issuer?.Log.Add(new GenericLogMessage("The server attempted to remove a null order from " + Executor + ". Perhaps this order was not actually on the server yet; it was just added and removed this past turn. This is probably a game bug."));
 			else if (Order.IsNew())
-				Issuer.Log.Add(new GenericLogMessage("The server attempted to remove an order from " + Executor + " that was not actually on the server; it was just added and removed this past turn. This is probably a game bug."));
+				Issuer?.Log.Add(new GenericLogMessage("The server attempted to remove an order from " + Executor + " that was not actually on the server; it was just added and removed this past turn. This is probably a game bug."));
 			else if (Executor == null)
-				Issuer.Log.Add(new GenericLogMessage("On your previous turn, you attempted to remove an order from an object with ID #" + executor.ID + ", but no such object exists. This is probably a game bug."));
+				Issuer?.Log.Add(new GenericLogMessage("On your previous turn, you attempted to remove an order from an object with ID #" + executor?.ID + ", but no such object exists. This is probably a game bug."));
 			else if (Issuer == Executor.Owner)
 			{
 				Executor.RemoveOrder(Order);
 				Galaxy.Current.UnassignID(Order);
 			}
 			else
-				Issuer.Log.Add(new GenericLogMessage(Issuer + " cannot issue commands to " + Executor + " belonging to " + Executor.Owner + "!", Galaxy.Current.TurnNumber));
+				Issuer?.Log.Add(new GenericLogMessage(Issuer + " cannot issue commands to " + Executor + " belonging to " + Executor.Owner + "!", Galaxy.Current.TurnNumber));
 		}
 	}
 }

--- a/FrEee/Game/Objects/Commands/ResearchCommand.cs
+++ b/FrEee/Game/Objects/Commands/ResearchCommand.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Objects.Civilization;
+using FrEee.Game.Objects.Civilization;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System.Linq;
 using Tech = FrEee.Game.Objects.Technology.Technology;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -36,22 +38,22 @@ namespace FrEee.Game.Objects.Commands
 			// make sure no techs are prioritized or queued that the empire can't research
 			foreach (var kvp in Spending.ToArray())
 			{
-				if (!Executor.HasUnlocked(kvp.Key))
+				if (!Executor?.HasUnlocked(kvp.Key) ?? false)
 					Spending[kvp.Key] = 0;
 			}
-			foreach (Technology.Technology tech in Queue.ToArray())
+			foreach (var tech in Queue.ToArray())
 			{
-				if (!Executor.HasUnlocked(tech))
+				if (!Executor?.HasUnlocked(tech) ?? false)
 					Queue.Remove(tech);
 			}
 
 			// save to empire
-			Executor.ResearchSpending.Clear();
+			Executor?.ResearchSpending.Clear();
 			foreach (var kvp in Spending)
-				Executor.ResearchSpending.Add(kvp);
-			Executor.ResearchQueue.Clear();
+				Executor?.ResearchSpending.Add(kvp);
+			Executor?.ResearchQueue.Clear();
 			foreach (var tech in Queue)
-				Executor.ResearchQueue.Add(tech);
+				Executor?.ResearchQueue.Add(tech);
 		}
 	}
 }

--- a/FrEee/Game/Objects/Commands/SendMessageCommand.cs
+++ b/FrEee/Game/Objects/Commands/SendMessageCommand.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Civilization.Diplomacy;
 using FrEee.Utility.Extensions;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -19,7 +21,7 @@ namespace FrEee.Game.Objects.Commands
 
 		public IMessage Message { get; set; }
 
-		public override IEnumerable<IReferrable> NewReferrables
+		public override IEnumerable<IReferrable?> NewReferrables
 		{
 			get
 			{
@@ -38,11 +40,11 @@ namespace FrEee.Game.Objects.Commands
 			if (Message is ActionMessage)
 			{
 				// execute unilateral action
-				((ActionMessage)Message).Action.Execute();
+				((ActionMessage)Message).Action?.Execute();
 			}
 		}
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();

--- a/FrEee/Game/Objects/Commands/SetObsoleteFlagCommand.cs
+++ b/FrEee/Game/Objects/Commands/SetObsoleteFlagCommand.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -24,7 +26,7 @@ namespace FrEee.Game.Objects.Commands
 		/// The design to set the flag on if it's already knwon by the server.
 		/// </summary>
 		[DoNotSerialize]
-		public IDesign Design { get { return design?.Value; } set { design = value.ReferViaGalaxy(); } }
+		public IDesign? Design { get => design?.Value; set => design = value.ReferViaGalaxy(); }
 
 		/// <summary>
 		/// The flag state to set.
@@ -34,7 +36,7 @@ namespace FrEee.Game.Objects.Commands
 		/// <summary>
 		/// The design to set the flag on if it's only in the library and not in the game or it's a brand new design.
 		/// </summary>
-		public IDesign NewDesign { get; set; }
+		public IDesign? NewDesign { get; set; }
 
 		public override IEnumerable<IReferrable> NewReferrables
 		{
@@ -45,20 +47,21 @@ namespace FrEee.Game.Objects.Commands
 			}
 		}
 
-		private GalaxyReference<IDesign> design { get; set; }
+		private GalaxyReference<IDesign?>? design { get; set; }
 
 		public override void Execute()
 		{
 			if (NewDesign != null)
 			{
 				// allows obsoleting designs that are on the library or newly created (not on the server yet)
-				Issuer.KnownDesigns.Add(NewDesign);
+				Issuer?.KnownDesigns.Add(NewDesign);
 				Design = NewDesign;
 			}
-			Design.IsObsolete = IsObsolete;
+			if (Design != null)
+				Design.IsObsolete = IsObsolete;
 		}
 
-		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public override void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();

--- a/FrEee/Game/Objects/Commands/SetPlayerInfoCommand.cs
+++ b/FrEee/Game/Objects/Commands/SetPlayerInfoCommand.cs
@@ -1,9 +1,10 @@
-﻿using FrEee.Game.Interfaces;
-using FrEee.Game.Objects.Civilization;
-using FrEee.Game.Objects.LogMessages;
-using FrEee.Game.Objects.Space;
 using System;
 using System.Collections.Generic;
+
+using FrEee.Game.Interfaces;
+using FrEee.Game.Objects.Civilization;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -29,9 +30,10 @@ namespace FrEee.Game.Objects.Commands
 
 		public override void Execute()
 		{
-			Executor.PlayerInfo = PlayerInfo;
+			if (Executor != null)
+				Executor.PlayerInfo = PlayerInfo;
 		}
 
-		public PlayerInfo PlayerInfo { get; set; }
+		public PlayerInfo? PlayerInfo { get; set; }
 	}
 }

--- a/FrEee/Game/Objects/Commands/SetPlayerNoteCommand.cs
+++ b/FrEee/Game/Objects/Commands/SetPlayerNoteCommand.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -20,12 +22,14 @@ namespace FrEee.Game.Objects.Commands
 		public string Note { get; set; }
 
 		[DoNotSerialize]
-		public IReferrable Target { get { return target.Value; } set { target = value.ReferViaGalaxy(); } }
+		public IReferrable? Target { get => target?.Value; set => target = value.ReferViaGalaxy(); }
 
-		private GalaxyReference<IReferrable> target { get; set; }
+		private GalaxyReference<IReferrable?>? target { get; set; }
 
 		public override void Execute()
 		{
+			if (Executor is null || target is null)
+				return;
 			Executor.PlayerNotes[target] = Note;
 		}
 	}

--- a/FrEee/Game/Objects/Commands/SetPrivateNameCommand.cs
+++ b/FrEee/Game/Objects/Commands/SetPrivateNameCommand.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -10,6 +12,7 @@ namespace FrEee.Game.Objects.Commands
 	/// </summary>
 	public class SetPrivateNameCommand : Command<Empire>
 	{
+		// TODO: why isn't "name" used here?
 		public SetPrivateNameCommand(Empire empire, INameable target, string name)
 			: base(empire)
 		{
@@ -19,18 +22,20 @@ namespace FrEee.Game.Objects.Commands
 		/// <summary>
 		/// The name to set.
 		/// </summary>
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
 		/// <summary>
 		/// What are we clearing the name on?
 		/// </summary>
 		[DoNotSerialize]
-		public INameable Target { get { return target.Value; } set { target = value.ReferViaGalaxy(); } }
+		public INameable? Target { get => target?.Value; set => target = value.ReferViaGalaxy(); }
 
-		private GalaxyReference<INameable> target { get; set; }
+		private GalaxyReference<INameable?>? target { get; set; }
 
 		public override void Execute()
 		{
+			if (Executor is null || target is null)
+				return;
 			Executor.PrivateNames[target] = Name;
 		}
 	}

--- a/FrEee/Game/Objects/Commands/SetPublicNameCommand.cs
+++ b/FrEee/Game/Objects/Commands/SetPublicNameCommand.cs
@@ -1,4 +1,6 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -20,6 +22,8 @@ namespace FrEee.Game.Objects.Commands
 
 		public override void Execute()
 		{
+			if (Executor is null)
+				return;
 			Executor.Name = Name;
 		}
 	}

--- a/FrEee/Game/Objects/Commands/ToggleOrdersOnHoldCommand.cs
+++ b/FrEee/Game/Objects/Commands/ToggleOrdersOnHoldCommand.cs
@@ -1,9 +1,11 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -19,6 +21,8 @@ namespace FrEee.Game.Objects.Commands
 
 		public override void Execute()
 		{
+			if (Executor is null)
+				return;
 			Executor.AreOrdersOnHold = AreOrdersOnHold;
 		}
 	}

--- a/FrEee/Game/Objects/Commands/ToggleRepeatOrdersCommand.cs
+++ b/FrEee/Game/Objects/Commands/ToggleRepeatOrdersCommand.cs
@@ -1,9 +1,6 @@
-﻿using FrEee.Game.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using FrEee.Game.Interfaces;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Commands
 {
@@ -19,6 +16,8 @@ namespace FrEee.Game.Objects.Commands
 
 		public override void Execute()
 		{
+			if (Executor is null)
+				return;
 			Executor.AreRepeatOrdersEnabled = AreRepeatOrdersEnabled;
 		}
 	}

--- a/FrEee/Game/Objects/Events/Event.cs
+++ b/FrEee/Game/Objects/Events/Event.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Space;
 using FrEee.Modding;
@@ -9,6 +9,8 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Events
 {
@@ -27,14 +29,8 @@ namespace FrEee.Game.Objects.Events
 		/// <summary>
 		/// The empires which are affected by this event and need log messages.
 		/// </summary>
-		public IEnumerable<Empire> AffectedEmpires
-		{
-			get
-			{
-				// TODO - affected empires only
-				return Galaxy.Current.Empires;
-			}
-		}
+		// TODO - affected empires only
+		public IEnumerable<Empire> AffectedEmpires => Galaxy.Current.Empires;
 
 		public Image Icon => Pictures.GetModImage(IconPaths.ToArray());
 
@@ -55,7 +51,7 @@ namespace FrEee.Game.Objects.Events
 		/// <summary>
 		/// The object affected by this script.
 		/// </summary>
-		public IReferrable Target { get; private set; }
+		public IReferrable? Target { get; private set; }
 
 		/// <summary>
 		/// The template for this event.
@@ -77,18 +73,19 @@ namespace FrEee.Game.Objects.Events
 				foreach (var emp in AffectedEmpires)
 				{
 					var context = new SafeDictionary<string, object>();
-					var text = m.Text.Evaluate(context);
-					emp.RecordLog(this, text, LogMessages.LogMessageType.Generic);
+					var text = m.Text?.Evaluate(context);
+					emp.RecordLog(this, text ?? string.Empty, LogMessages.LogMessageType.Generic);
 				}
 			}
 
-			var dict = new SafeDictionary<string, object>();
+			var dict = new SafeDictionary<string, object?>();
 			dict.Add("target", Target);
 			// SE4/SE5 style replacement strings turn into dynamic formulas
 			var regex = new Regex(@"\[\%(.*?)\%?\]");
 			var matches = regex.Matches(Template.Type.Action.Text);
-			foreach (Match m in matches)
-				dict.Add(m.Captures[0].Value, new ComputedFormula<string>(m.Captures[0].Value, this, true).Value);
+			foreach (Match? m in matches)
+				if (m?.Captures[0].Value != null)
+					dict.Add(m.Captures[0].Value, new ComputedFormula<string>(m.Captures[0].Value, this, true).Value);
 			PythonScriptEngine.RunScript(Template.Type.Action, dict);
 		}
 
@@ -145,8 +142,8 @@ namespace FrEee.Game.Objects.Events
 				foreach (var emp in AffectedEmpires)
 				{
 					var context = new SafeDictionary<string, object>();
-					var text = m.Text.Evaluate(context);
-					emp.RecordLog(this, text, LogMessages.LogMessageType.Generic);
+					var text = m.Text?.Evaluate(context);
+					emp.RecordLog(this, text ?? string.Empty, LogMessages.LogMessageType.Generic);
 				}
 			}
 		}

--- a/FrEee/Game/Objects/Events/EventMessage.cs
+++ b/FrEee/Game/Objects/Events/EventMessage.cs
@@ -1,9 +1,6 @@
-﻿using FrEee.Modding.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using FrEee.Modding.Interfaces;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Events
 {
@@ -12,7 +9,7 @@ namespace FrEee.Game.Objects.Events
 	/// </summary>
 	public class EventMessage
 	{
-		public IFormula<string> Title { get; set; }
-		public IFormula<string> Text { get; set; }
+		public IFormula<string>? Title { get; set; }
+		public IFormula<string>? Text { get; set; }
 	}
 }

--- a/FrEee/Game/Objects/LogMessages/GenericLogMessage.cs
+++ b/FrEee/Game/Objects/LogMessages/GenericLogMessage.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.LogMessages
 {
@@ -16,9 +18,6 @@ namespace FrEee.Game.Objects.LogMessages
 		public GenericLogMessage(string text, int turn, LogMessageType logMessageType = LogMessageType.Generic) : base(text, turn, logMessageType)
 		{ }
 
-		public override System.Drawing.Image Picture
-		{
-			get { return null; }
-		}
+		public override System.Drawing.Image? Picture => null;
 	}
 }

--- a/FrEee/Game/Objects/LogMessages/LogMessage.cs
+++ b/FrEee/Game/Objects/LogMessages/LogMessage.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Objects.Space;
+using FrEee.Game.Objects.Space;
 using System;
 using System.Drawing;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.LogMessages
 {
@@ -24,7 +26,7 @@ namespace FrEee.Game.Objects.LogMessages
 		/// <summary>
 		/// A picture to display with the log message.
 		/// </summary>
-		public abstract Image Picture { get; }
+		public abstract Image? Picture { get; }
 
 		/// <summary>
 		/// The text of the log message.

--- a/FrEee/Game/Objects/LogMessages/PictorialLogMessage.cs
+++ b/FrEee/Game/Objects/LogMessages/PictorialLogMessage.cs
@@ -1,6 +1,8 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using System;
 using System.Drawing;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.LogMessages
 {
@@ -28,7 +30,7 @@ namespace FrEee.Game.Objects.LogMessages
 		/// </summary>
 		public T Context { get; set; }
 
-		public override Image Picture
+		public override Image? Picture
 		{
 			get
 			{

--- a/FrEee/Game/Objects/Orders/ColonizeOrder.cs
+++ b/FrEee/Game/Objects/Orders/ColonizeOrder.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
@@ -10,6 +10,8 @@ using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Orders
 {
@@ -25,18 +27,11 @@ namespace FrEee.Game.Objects.Orders
 			Planet = planet;
 		}
 
-		public bool ConsumesMovement
-		{
-			get { return true; }
-		}
+		public bool ConsumesMovement => true;
 
 		public long ID { get; set; }
 
-		public bool IsComplete
-		{
-			get;
-			set;
-		}
+		public bool IsComplete { get; set; }
 
 		public bool IsDisposed { get; set; }
 
@@ -44,21 +39,18 @@ namespace FrEee.Game.Objects.Orders
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire? Owner { get => owner; set => owner = value; }
 
 		/// <summary>
 		/// The planet we are colonizing.
 		/// </summary>
 		[DoNotSerialize]
-		public Planet Planet { get { return planet; } set { planet = value; } }
+		public Planet Planet { get => planet; set => planet = value; }
 
-		private GalaxyReference<Empire> owner { get; set; }
-		private GalaxyReference<Planet> planet { get; set; }
+		private GalaxyReference<Empire?>? owner { get; set; }
+		private GalaxyReference<Planet>? planet { get; set; }
 
-		public bool CheckCompletion(IOrderable v)
-		{
-			return IsComplete;
-		}
+		public bool CheckCompletion(IOrderable v) => IsComplete;
 
 		/// <summary>
 		/// Orders are visible only to their owners.
@@ -105,7 +97,7 @@ namespace FrEee.Game.Objects.Orders
 				{
 					// colonize now!!!
 					Planet.Colony = new Colony { Owner = sobj.Owner };
-					Owner.TriggerHappinessChange(hm => hm.PlanetColonized);
+					Owner?.TriggerHappinessChange(hm => hm.PlanetColonized);
 					Planet.Colony.ConstructionQueue = new ConstructionQueue(Planet);
 					if (sobj is ICargoContainer cc)
 					{
@@ -191,7 +183,7 @@ namespace FrEee.Game.Objects.Orders
 				sobj.SpendTime(sobj.TimePerMove);
 			}
 			else
-				Owner.Log.Append(Owner.CreateLogMessage($"Could not assign a colonize order to ${ord} because it is not a mobile space object.", LogMessageType.Error));
+				Owner?.Log.Append(Owner.CreateLogMessage($"Could not assign a colonize order to ${ord} because it is not a mobile space object.", LogMessageType.Error));
 		}
 
 		public IEnumerable<LogMessage> GetErrors(IOrderable o)
@@ -213,29 +205,26 @@ namespace FrEee.Game.Objects.Orders
 					// no such colony module
 					yield return sobj.CreateLogMessage(sobj + " cannot colonize " + Planet + " because it lacks a " + Planet.Surface + " colony module.", LogMessageType.Warning);
 				}
-				if (Galaxy.Current.CanColonizeOnlyBreathable && Planet.Atmosphere != sobj.Owner.PrimaryRace.NativeAtmosphere)
+				if (Galaxy.Current.CanColonizeOnlyBreathable && Planet.Atmosphere != sobj.Owner.PrimaryRace?.NativeAtmosphere)
 				{
 					// can only colonize breathable atmosphere (due to game setup option)
-					yield return sobj.CreateLogMessage(sobj + " cannot colonize " + Planet + " because we can only colonize " + sobj.Owner.PrimaryRace.NativeAtmosphere + " planets.", LogMessageType.Warning);
+					yield return sobj.CreateLogMessage(sobj + " cannot colonize " + Planet + " because we can only colonize " + sobj.Owner.PrimaryRace?.NativeAtmosphere + " planets.", LogMessageType.Warning);
 				}
-				if (Galaxy.Current.CanColonizeOnlyHomeworldSurface && Planet.Surface != sobj.Owner.PrimaryRace.NativeSurface)
+				if (Galaxy.Current.CanColonizeOnlyHomeworldSurface && Planet.Surface != sobj.Owner.PrimaryRace?.NativeSurface)
 				{
 					// can only colonize breathable atmosphere (due to game setup option)
-					yield return sobj.CreateLogMessage(sobj + " cannot colonize " + Planet + " because we can only colonize " + sobj.Owner.PrimaryRace.NativeSurface + " planets.", LogMessageType.Warning);
+					yield return sobj.CreateLogMessage(sobj + " cannot colonize " + Planet + " because we can only colonize " + sobj.Owner.PrimaryRace?.NativeSurface + " planets.", LogMessageType.Warning);
 				}
 			}
 			else
 				yield return o.CreateLogMessage($"{o} cannot colonize {Planet} because it is not a mobile space object.", LogMessageType.Error);
 		}
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			// This type does not use client objects, so nothing to do here.
 		}
 
-		public override string ToString()
-		{
-			return "Colonize " + Planet.Name;
-		}
+		public override string ToString() => "Colonize " + Planet.Name;
 	}
 }

--- a/FrEee/Game/Objects/Orders/ColonizeOrder.cs
+++ b/FrEee/Game/Objects/Orders/ColonizeOrder.cs
@@ -23,8 +23,8 @@ namespace FrEee.Game.Objects.Orders
 	{
 		public ColonizeOrder(Planet planet)
 		{
-			Owner = Empire.Current;
-			Planet = planet;
+			owner = Empire.Current;
+			this.planet = planet;
 		}
 
 		public bool ConsumesMovement => true;
@@ -39,7 +39,7 @@ namespace FrEee.Game.Objects.Orders
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire? Owner { get => owner; set => owner = value; }
+		public Empire Owner { get => owner; set => owner = value; }
 
 		/// <summary>
 		/// The planet we are colonizing.
@@ -47,8 +47,8 @@ namespace FrEee.Game.Objects.Orders
 		[DoNotSerialize]
 		public Planet Planet { get => planet; set => planet = value; }
 
-		private GalaxyReference<Empire?>? owner { get; set; }
-		private GalaxyReference<Planet>? planet { get; set; }
+		private GalaxyReference<Empire> owner { get; set; }
+		private GalaxyReference<Planet> planet { get; set; }
 
 		public bool CheckCompletion(IOrderable v) => IsComplete;
 

--- a/FrEee/Game/Objects/Orders/ConstructionOrder.cs
+++ b/FrEee/Game/Objects/Orders/ConstructionOrder.cs
@@ -25,7 +25,7 @@ namespace FrEee.Game.Objects.Orders
 		where T : class, IConstructable
 		where TTemplate : class, ITemplate<T>, IReferrable, IConstructionTemplate
 	{
-		public ConstructionOrder() => Owner = Empire.Current;
+		public ConstructionOrder() => owner = Empire.Current;
 
 		public bool ConsumesMovement => false;
 
@@ -55,7 +55,7 @@ namespace FrEee.Game.Objects.Orders
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire? Owner { get => owner; set => owner = value; }
+		public Empire Owner { get => owner; set => owner = value; }
 
 		/// <summary>
 		/// The construction template.
@@ -91,7 +91,7 @@ namespace FrEee.Game.Objects.Orders
 		[DoNotSerialize]
 		private bool? isComplete { get; set; }
 
-		private GalaxyReference<Empire?>? owner { get; set; }
+		private GalaxyReference<Empire> owner { get; set; }
 		private IReference<TTemplate>? template { get; set; }
 
 		public bool CheckCompletion(IOrderable q)

--- a/FrEee/Game/Objects/Orders/EvadeOrder.cs
+++ b/FrEee/Game/Objects/Orders/EvadeOrder.cs
@@ -1,10 +1,12 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Space;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Orders
 {
@@ -20,10 +22,7 @@ namespace FrEee.Game.Objects.Orders
 		{
 		}
 
-		public override string Verb
-		{
-			get { return "evade"; }
-		}
+		public override string Verb => "evade";
 
 		/// <summary>
 		/// Finds the path for executing this order.
@@ -68,7 +67,7 @@ namespace FrEee.Game.Objects.Orders
 			else
 			{
 				// target is immobile! no need to flee, unless it's in the same sector
-				if (Target.Sector == me.FindSector())
+				if (Target?.Sector == me.FindSector())
 				{
 					// don't need to go through warp points to evade it, the warp points might be one way!
 					var moves = Pathfinder.GetPossibleMoves(me.Sector, false, me.Owner);
@@ -79,10 +78,7 @@ namespace FrEee.Game.Objects.Orders
 			}
 		}
 
-		protected override bool AreWeThereYet(IMobileSpaceObject me)
-		{
-			// gotta keep on running...
-			return Target == null || Target.IsDisposed;
-		}
+		// gotta keep on running...
+		protected override bool AreWeThereYet(IMobileSpaceObject me) => Target == null || Target.IsDisposed;
 	}
 }

--- a/FrEee/Game/Objects/Orders/EvadeOrder.cs
+++ b/FrEee/Game/Objects/Orders/EvadeOrder.cs
@@ -29,7 +29,7 @@ namespace FrEee.Game.Objects.Orders
 		/// </summary>
 		/// <param name="sobj">The space object executing the order.</param>
 		/// <returns></returns>
-		public override IEnumerable<Sector> Pathfind(IMobileSpaceObject me, Sector start)
+		public override IEnumerable<Sector?>? Pathfind(IMobileSpaceObject me, Sector start)
 		{
 			if (Target is IMobileSpaceObject)
 			{
@@ -38,13 +38,13 @@ namespace FrEee.Game.Objects.Orders
 					// warping via any warp point that leads outside the system should be safe, so prioritize those!
 					var sys = me.FindStarSystem();
 					var paths = sys.FindSpaceObjects<WarpPoint>()
-						.Where(wp => wp.TargetStarSystemLocation == null || wp.TargetStarSystemLocation.Item != sys)
+						.Where(wp => wp.TargetStarSystemLocation is null || wp.TargetStarSystemLocation.Item != sys)
 						.Select(wp => new { WarpPoint = wp, Path = Pathfinder.Pathfind(me, start, wp.Sector, AvoidEnemies, true, me.DijkstraMap) });
 					if (paths.Any())
 					{
 						// found a warp point to flee to!
 						var shortest = paths.WithMin(path => path.Path.Count()).PickRandom();
-						return shortest.Path.Concat(new Sector[] { shortest.WarpPoint.Target });
+						return shortest?.Path.Concat(new Sector?[] { shortest.WarpPoint.Target });
 					}
 				}
 
@@ -56,7 +56,7 @@ namespace FrEee.Game.Objects.Orders
 				if (goodMoves.Any())
 				{
 					// just go there and recompute the path next time we can move - the enemy may have moved too
-					return new Sector[] { goodMoves.PickRandom() };
+					return new Sector?[] { goodMoves.PickRandom() };
 				}
 				else
 				{
@@ -71,7 +71,7 @@ namespace FrEee.Game.Objects.Orders
 				{
 					// don't need to go through warp points to evade it, the warp points might be one way!
 					var moves = Pathfinder.GetPossibleMoves(me.Sector, false, me.Owner);
-					return new Sector[] { moves.PickRandom() };
+					return new Sector?[] { moves.PickRandom() };
 				}
 				else
 					return Enumerable.Empty<Sector>();

--- a/FrEee/Game/Objects/Orders/MoveOrder.cs
+++ b/FrEee/Game/Objects/Orders/MoveOrder.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Combat;
@@ -10,6 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Orders
 {
 	/// <summary>
@@ -20,7 +22,7 @@ namespace FrEee.Game.Objects.Orders
 	{
 		public MoveOrder(Sector destination, bool avoidEnemies)
 		{
-			Owner = Empire.Current;
+			owner = Empire.Current;
 			Destination = destination;
 			AvoidEnemies = avoidEnemies;
 			// TODO - add flag for "avoid damaging sectors"? but how to specify in UI?
@@ -31,10 +33,7 @@ namespace FrEee.Game.Objects.Orders
 		/// </summary>
 		public bool AvoidEnemies { get; set; }
 
-		public bool ConsumesMovement
-		{
-			get { return true; }
-		}
+		public bool ConsumesMovement => true;
 
 		/// <summary>
 		/// The sector we are moving to.
@@ -43,11 +42,7 @@ namespace FrEee.Game.Objects.Orders
 
 		public long ID { get; set; }
 
-		public bool IsComplete
-		{
-			get;
-			set;
-		}
+		public bool IsComplete { get; set; }
 
 		public bool IsDisposed { get; set; }
 
@@ -61,32 +56,24 @@ namespace FrEee.Game.Objects.Orders
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire Owner { get => owner; set => owner = value; }
 
 		/// <summary>
 		/// Any pathfinding error that we might have found.
 		/// </summary>
 		[DoNotSerialize]
-		public LogMessage PathfindingError { get; private set; }
+		public LogMessage? PathfindingError { get; private set; }
 
 		private GalaxyReference<Empire> owner { get; set; }
 
-		public bool CheckCompletion(IOrderable v)
-		{
-			return IsComplete;
-		}
+		public bool CheckCompletion(IOrderable v) => IsComplete;
 
 		/// <summary>
 		/// Orders are visible only to their owners.
 		/// </summary>
 		/// <param name="emp"></param>
 		/// <returns></returns>
-		public Visibility CheckVisibility(Empire emp)
-		{
-			if (emp == Owner)
-				return Visibility.Visible;
-			return Visibility.Unknown;
-		}
+		public Visibility CheckVisibility(Empire emp) => emp == Owner ? Visibility.Visible : Visibility.Unknown;
 
 		/// <summary>
 		/// Creates a Dijkstra map for this order's movement.
@@ -95,9 +82,7 @@ namespace FrEee.Game.Objects.Orders
 		/// <param name="start"></param>
 		/// <returns></returns>
 		public IDictionary<PathfinderNode<Sector>, ISet<PathfinderNode<Sector>>> CreateDijkstraMap(IMobileSpaceObject me, Sector start)
-		{
-			return Pathfinder.CreateDijkstraMap(me, start, Destination, AvoidEnemies, true);
-		}
+			=> Pathfinder.CreateDijkstraMap(me, start, Destination, AvoidEnemies, true);
 
 		public void Dispose()
 		{
@@ -195,9 +180,7 @@ namespace FrEee.Game.Objects.Orders
 		/// <param name="sobj">The space object executing the order.</param>
 		/// <returns></returns>
 		public IEnumerable<Sector> Pathfind(IMobileSpaceObject me, Sector start)
-		{
-			return Pathfinder.Pathfind(me, start, Destination, AvoidEnemies, true, me.DijkstraMap);
-		}
+			=> Pathfinder.Pathfind(me, start, Destination, AvoidEnemies, true, me.DijkstraMap);
 
 		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done)
 		{

--- a/FrEee/Game/Objects/Orders/PathfindingOrder.cs
+++ b/FrEee/Game/Objects/Orders/PathfindingOrder.cs
@@ -1,13 +1,14 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
 using FrEee.Game.Objects.Space;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
-using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Orders
 {
@@ -20,7 +21,7 @@ namespace FrEee.Game.Objects.Orders
 	{
 		protected PathfindingOrder(ISpaceObject target, bool avoidEnemies)
 		{
-			Owner = Empire.Current;
+			owner = Empire.Current;
 			Target = target;
 			AvoidEnemies = avoidEnemies;
 			// TODO - add flag for "avoid damaging sectors"? but how to specify in UI?
@@ -30,41 +31,27 @@ namespace FrEee.Game.Objects.Orders
 		/// Alternate target. This should be the largest ship in a fleet when a fleet is being pursued.
 		/// </summary>
 		[DoNotSerialize]
-		public ISpaceObject AlternateTarget
-		{
-			get;
-			private set;
-		}
+		public ISpaceObject? AlternateTarget { get; private set; }
 
 		/// <summary>
 		/// Should pathfinding avoid enemies?
 		/// </summary>
 		public bool AvoidEnemies { get; set; }
 
-		public bool ConsumesMovement
-		{
-			get { return true; }
-		}
+		public bool ConsumesMovement => true;
 
-		public Sector Destination
-		{
-			get { return KnownTarget?.Sector; }
-		}
+		public Sector? Destination => KnownTarget?.Sector;
 
 		public long ID { get; set; }
 
-		public bool IsComplete
-		{
-			get;
-			set;
-		}
+		public bool IsComplete { get; set; }
 
 		public bool IsDisposed { get; set; }
 
 		/// <summary>
 		/// Either the target itself, or the memory of the target, if it's not visible.
 		/// </summary>
-		public ISpaceObject KnownTarget
+		public ISpaceObject? KnownTarget
 		{
 			get
 			{
@@ -86,19 +73,19 @@ namespace FrEee.Game.Objects.Orders
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire Owner { get => owner; set => owner = value; }
 
 		/// <summary>
 		/// Any pathfinding error that we might have found.
 		/// </summary>
 		[DoNotSerialize]
-		public LogMessage PathfindingError { get; private set; }
+		public LogMessage? PathfindingError { get; private set; }
 
 		/// <summary>
 		/// The target we are pursuing.
 		/// </summary>
 		[DoNotSerialize]
-		public ISpaceObject Target { get { return target?.Value; } set { target = value.ReferViaGalaxy(); } }
+		public ISpaceObject? Target { get => target?.Value; set => target = value.ReferViaGalaxy(); }
 
 		/// <summary>
 		/// A verb used to describe this order.
@@ -106,29 +93,19 @@ namespace FrEee.Game.Objects.Orders
 		public abstract string Verb { get; }
 
 		private GalaxyReference<Empire> owner { get; set; }
-		private GalaxyReference<ISpaceObject> target { get; set; }
+		private GalaxyReference<ISpaceObject?>? target { get; set; }
 
-		public bool CheckCompletion(IOrderable v)
-		{
-			return IsComplete;
-		}
+		public bool CheckCompletion(IOrderable v) => IsComplete;
 
 		/// <summary>
 		/// Orders are visible only to their owners.
 		/// </summary>
 		/// <param name="emp"></param>
 		/// <returns></returns>
-		public Visibility CheckVisibility(Empire emp)
-		{
-			if (emp == Owner)
-				return Visibility.Visible;
-			return Visibility.Unknown;
-		}
+		public Visibility CheckVisibility(Empire emp) => emp == Owner ? Visibility.Visible : Visibility.Unknown;
 
 		public IDictionary<PathfinderNode<Sector>, ISet<PathfinderNode<Sector>>> CreateDijkstraMap(IMobileSpaceObject me, Sector start)
-		{
-			return Pathfinder.CreateDijkstraMap(me, start, Destination, AvoidEnemies, true);
-		}
+			=> Pathfinder.CreateDijkstraMap(me, start, Destination, AvoidEnemies, true);
 
 		public void Dispose()
 		{

--- a/FrEee/Game/Objects/Orders/PathfindingOrder.cs
+++ b/FrEee/Game/Objects/Orders/PathfindingOrder.cs
@@ -209,7 +209,7 @@ namespace FrEee.Game.Objects.Orders
 		/// <param name="sobj">The space object executing the order.</param>
 		/// <param name="start">The start location (need not be the current location, in case there are prior orders queued).</param>
 		/// <returns></returns>
-		public abstract IEnumerable<Sector> Pathfind(IMobileSpaceObject me, Sector start);
+		public abstract IEnumerable<Sector?>? Pathfind(IMobileSpaceObject me, Sector start);
 
 		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done)
 		{

--- a/FrEee/Game/Objects/Orders/PursueOrder.cs
+++ b/FrEee/Game/Objects/Orders/PursueOrder.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Space;
 using FrEee.Utility;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Orders
 {
@@ -23,7 +25,7 @@ namespace FrEee.Game.Objects.Orders
 			{
 				if (KnownTarget == null)
 					return "pursue";
-				else if (AvoidEnemies && KnownTarget.Owner != null && (!(KnownTarget is ICombatant) || !(KnownTarget as ICombatant).IsHostileTo(Owner)))
+				else if (AvoidEnemies && KnownTarget.Owner != null && (!(KnownTarget is ICombatant) || !((ICombatant)KnownTarget).IsHostileTo(Owner)))
 					return "escort";
 				else
 					return "pursue";
@@ -40,9 +42,6 @@ namespace FrEee.Game.Objects.Orders
 			return Pathfinder.Pathfind(me, start, Destination, AvoidEnemies, true, me.DijkstraMap);
 		}
 
-		protected override bool AreWeThereYet(IMobileSpaceObject me)
-		{
-			return me.Sector == Destination;
-		}
+		protected override bool AreWeThereYet(IMobileSpaceObject me) => me.Sector == Destination;
 	}
 }

--- a/FrEee/Game/Objects/Orders/RecycleBehaviors/ScrapBehavior.cs
+++ b/FrEee/Game/Objects/Orders/RecycleBehaviors/ScrapBehavior.cs
@@ -1,10 +1,12 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.LogMessages;
 using FrEee.Game.Objects.Space;
 using FrEee.Game.Objects.Vehicles;
 using FrEee.Utility.Extensions;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Orders.RecycleBehaviors
 {
@@ -14,7 +16,7 @@ namespace FrEee.Game.Objects.Orders.RecycleBehaviors
 	/// </summary>
 	public class ScrapBehavior : IRecycleBehavior
 	{
-		public string Verb { get { return "Scrap"; } }
+		public string Verb => "Scrap";
 
 		public void Execute(IRecyclable target, bool didRecycle = false)
 		{

--- a/FrEee/Game/Objects/Orders/RecycleFacilityOrCargoOrder.cs
+++ b/FrEee/Game/Objects/Orders/RecycleFacilityOrCargoOrder.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
 using FrEee.Game.Objects.Space;
@@ -6,6 +6,8 @@ using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Orders
 {
@@ -19,48 +21,30 @@ namespace FrEee.Game.Objects.Orders
 
 		public IRecycleBehavior Behavior { get; private set; }
 
-		public bool ConsumesMovement
-		{
-			get { return false; }
-		}
+		public bool ConsumesMovement => false;
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
-		public bool IsComplete
-		{
-			get;
-			set;
-		}
+		public bool IsComplete { get; set; }
 
-		public bool IsDisposed
-		{
-			get;
-			set;
-		}
+		public bool IsDisposed { get; set; }
 
 		/// <summary>
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire? Owner { get => owner; set => owner = value; }
 
 		/// <summary>
 		/// The facility or unit in cargo to recycle.
 		/// </summary>
 		[DoNotSerialize]
-		public IRecyclable Target { get { return target.Value; } set { target = value.ReferViaGalaxy(); } }
+		public IRecyclable? Target { get => target?.Value; set => target = value.ReferViaGalaxy(); }
 
-		private GalaxyReference<Empire> owner { get; set; }
-		private GalaxyReference<IRecyclable> target { get; set; }
+		private GalaxyReference<Empire?>? owner { get; set; }
+		private GalaxyReference<IRecyclable?>? target { get; set; }
 
-		public bool CheckCompletion(IOrderable executor)
-		{
-			return IsComplete;
-		}
+		public bool CheckCompletion(IOrderable executor) => IsComplete;
 
 		public void Dispose()
 		{
@@ -93,10 +77,7 @@ namespace FrEee.Game.Objects.Orders
 			IsComplete = true;
 		}
 
-		public IEnumerable<LogMessage> GetErrors(IOrderable executor)
-		{
-			return Behavior.GetErrors(executor as IMobileSpaceObject, Target).Concat(SelfErrors);
-		}
+		public IEnumerable<LogMessage> GetErrors(IOrderable executor) => Behavior.GetErrors(executor as IMobileSpaceObject, Target).Concat(SelfErrors);
 
 		private IEnumerable<LogMessage> SelfErrors
 		{
@@ -107,14 +88,11 @@ namespace FrEee.Game.Objects.Orders
 			}
 		}
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			// This type does not use client objects, so nothing to do here.
 		}
 
-		public override string ToString()
-		{
-			return Behavior.Verb + " " + Target;
-		}
+		public override string ToString() => Behavior.Verb + " " + Target;
 	}
 }

--- a/FrEee/Game/Objects/Orders/RecycleVehicleInSpaceOrder.cs
+++ b/FrEee/Game/Objects/Orders/RecycleVehicleInSpaceOrder.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
 using FrEee.Game.Objects.Space;
@@ -7,52 +7,33 @@ using FrEee.Utility;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Orders
 {
 	public class RecycleVehicleInSpaceOrder : IOrder
 	{
-		public RecycleVehicleInSpaceOrder(IRecycleBehavior behavior)
-		{
-			Behavior = behavior;
-		}
+		public RecycleVehicleInSpaceOrder(IRecycleBehavior behavior) => Behavior = behavior;
 
 		public IRecycleBehavior Behavior { get; private set; }
 
-		public bool ConsumesMovement
-		{
-			get { return false; }
-		}
+		public bool ConsumesMovement => false;
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
-		public bool IsComplete
-		{
-			get;
-			set;
-		}
+		public bool IsComplete { get; set; }
 
-		public bool IsDisposed
-		{
-			get;
-			set;
-		}
+		public bool IsDisposed { get; set; }
 
 		/// <summary>
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire? Owner { get => owner; set => owner = value; }
 
-		private GalaxyReference<Empire> owner { get; set; }
+		private GalaxyReference<Empire?>? owner { get; set; }
 
-		public bool CheckCompletion(IOrderable executor)
-		{
-			return IsComplete;
-		}
+		public bool CheckCompletion(IOrderable executor) => IsComplete;
 
 		public void Dispose()
 		{
@@ -77,19 +58,13 @@ namespace FrEee.Game.Objects.Orders
 			IsComplete = true;
 		}
 
-		public IEnumerable<LogMessage> GetErrors(IOrderable executor)
-		{
-			return Behavior.GetErrors(executor as IMobileSpaceObject, executor as IRecyclable);
-		}
+		public IEnumerable<LogMessage> GetErrors(IOrderable executor) => Behavior.GetErrors(executor as IMobileSpaceObject, executor as IRecyclable);
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			// This type does not use client objects, so nothing to do here.
 		}
 
-		public override string ToString()
-		{
-			return Behavior.Verb;
-		}
+		public override string ToString() => Behavior.Verb;
 	}
 }

--- a/FrEee/Game/Objects/Orders/SentryOrder.cs
+++ b/FrEee/Game/Objects/Orders/SentryOrder.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
@@ -10,6 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Orders
 {
 	/// <summary>
@@ -20,21 +22,14 @@ namespace FrEee.Game.Objects.Orders
 	{
 		public SentryOrder()
 		{
-			Owner = Empire.Current;
+			owner = Empire.Current;
 		}
 
-		public bool ConsumesMovement
-		{
-			get { return true; }
-		}
+		public bool ConsumesMovement => true;
 
 		public long ID { get; set; }
 
-		public bool IsComplete
-		{
-			get;
-			set;
-		}
+		public bool IsComplete { get; set; }
 
 		public bool IsDisposed { get; set; }
 
@@ -42,14 +37,11 @@ namespace FrEee.Game.Objects.Orders
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire Owner { get => owner; set => owner = value; }
 
 		private GalaxyReference<Empire> owner { get; set; }
 
-		public bool CheckCompletion(IOrderable v)
-		{
-			return IsComplete;
-		}
+		public bool CheckCompletion(IOrderable v) => IsComplete;
 
 		/// <summary>
 		/// Orders are visible only to their owners.
@@ -93,14 +85,11 @@ namespace FrEee.Game.Objects.Orders
 			yield break;
 		}
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			// This type does not use client objects, so nothing to do here.
 		}
 
-		public override string ToString()
-		{
-			return "Sentry";
-		}
+		public override string ToString() => "Sentry";
 	}
 }

--- a/FrEee/Game/Objects/Orders/TransferCargoOrder.cs
+++ b/FrEee/Game/Objects/Orders/TransferCargoOrder.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
 using FrEee.Game.Objects.Space;
@@ -6,6 +6,8 @@ using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Orders
 {
@@ -16,7 +18,7 @@ namespace FrEee.Game.Objects.Orders
 	{
 		public TransferCargoOrder(bool isLoadOrder, CargoDelta cargoDelta, ICargoTransferrer target)
 		{
-			Owner = Empire.Current;
+			owner = Empire.Current;
 			IsLoadOrder = isLoadOrder;
 			CargoDelta = cargoDelta;
 			Target = target;
@@ -27,18 +29,11 @@ namespace FrEee.Game.Objects.Orders
 		/// </summary>
 		public CargoDelta CargoDelta { get; set; }
 
-		public bool ConsumesMovement
-		{
-			get { return false; }
-		}
+		public bool ConsumesMovement => false;
 
 		public long ID { get; set; }
 
-		public bool IsComplete
-		{
-			get;
-			set;
-		}
+		public bool IsComplete { get; set; }
 
 		public bool IsDisposed { get; set; }
 
@@ -46,13 +41,13 @@ namespace FrEee.Game.Objects.Orders
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire Owner { get => owner; set => owner = value; }
 
 		/// <summary>
 		/// The cargo transferrer to which the cargo will be transferred, or null to launch/recover to/from space.
 		/// </summary>
 		[DoNotSerialize]
-		public ICargoTransferrer Target { get { return target?.Value; } set { target = value.ReferViaGalaxy(); } }
+		public ICargoTransferrer? Target { get => target?.Value; set => target = value.ReferViaGalaxy(); }
 
 		/// <summary>
 		/// True if this is a load order, false if it is a drop order.
@@ -60,12 +55,9 @@ namespace FrEee.Game.Objects.Orders
 		private bool IsLoadOrder { get; set; }
 
 		private GalaxyReference<Empire> owner { get; set; }
-		private GalaxyReference<ICargoTransferrer> target { get; set; }
+		private GalaxyReference<ICargoTransferrer?>? target { get; set; }
 
-		public bool CheckCompletion(IOrderable v)
-		{
-			return IsComplete;
-		}
+		public bool CheckCompletion(IOrderable v) => IsComplete;
 
 		public void Dispose()
 		{
@@ -109,7 +101,7 @@ namespace FrEee.Game.Objects.Orders
 				yield return executor.CreateLogMessage($"{executor} cannot transfer cargo.", LogMessageType.Warning);
 		}
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();
@@ -125,17 +117,11 @@ namespace FrEee.Game.Objects.Orders
 		{
 			if (Target == null)
 			{
-				if (IsLoadOrder)
-					return "Recover " + CargoDelta;
-				else
-					return "Launch " + CargoDelta;
+				return IsLoadOrder ? $"Recover {CargoDelta}" : $"Launch {CargoDelta}";
 			}
 			else
 			{
-				if (IsLoadOrder)
-					return "Load " + CargoDelta + " from " + Target;
-				else
-					return "Drop " + CargoDelta + " at " + Target;
+				return IsLoadOrder ? $"Load {CargoDelta} from {Target}" : $"Drop {CargoDelta} at {Target}";
 			}
 		}
 	}

--- a/FrEee/Game/Objects/Orders/UpgradeFacilityOrder.cs
+++ b/FrEee/Game/Objects/Orders/UpgradeFacilityOrder.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
@@ -10,6 +10,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Orders
 {
 	/// <summary>
@@ -20,19 +22,13 @@ namespace FrEee.Game.Objects.Orders
 	{
 		public UpgradeFacilityOrder(FacilityUpgrade fu)
 		{
-			Owner = Empire.Current;
+			owner = Empire.Current;
 			Upgrade = fu;
 		}
 
-		public bool ConsumesMovement
-		{
-			get { return false; }
-		}
+		public bool ConsumesMovement => false;
 
-		public ResourceQuantity Cost
-		{
-			get { return Upgrade.Cost; }
-		}
+		public ResourceQuantity Cost => Upgrade.Cost;
 
 		public long ID { get; set; }
 
@@ -44,37 +40,27 @@ namespace FrEee.Game.Objects.Orders
 					return false; // haven't checked completion yet, so it's probably safe to say it's incomplete
 				return isComplete.Value;
 			}
-			set
-			{ isComplete = value; }
+			set => isComplete = value;
 		}
 
 		public bool IsDisposed { get; set; }
 
-		IConstructable IConstructionOrder.Item
-		{
-			get { return NewFacility; }
-		}
+		IConstructable? IConstructionOrder.Item => NewFacility;
 
-		public string Name
-		{
-			get
-			{
-				return "Upgrade to " + Upgrade.New.Name;
-			}
-		}
+		public string Name => "Upgrade to " + Upgrade.New.Name;
 
 		/// <summary>
 		/// The facility being built.
 		/// </summary>
-		public Facility NewFacility { get; set; }
+		public Facility? NewFacility { get; set; }
 
 		/// <summary>
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire Owner { get => owner; set => owner = value; }
 
-		IConstructionTemplate IConstructionOrder.Template { get { return Upgrade.New; } }
+		IConstructionTemplate IConstructionOrder.Template => Upgrade.New;
 
 		/// <summary>
 		/// The upgrade to perform.
@@ -82,11 +68,7 @@ namespace FrEee.Game.Objects.Orders
 		public FacilityUpgrade Upgrade { get; set; }
 
 		[DoNotSerialize]
-		private bool? isComplete
-		{
-			get;
-			set;
-		}
+		private bool? isComplete { get; set; }
 
 		private GalaxyReference<Empire> owner { get; set; }
 
@@ -181,7 +163,7 @@ namespace FrEee.Game.Objects.Orders
 				yield return ord.CreateLogMessage($"{ord} cannot upgrade facilities because it is not a construction queue.", LogMessageType.Error);
 		}
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();
@@ -192,9 +174,6 @@ namespace FrEee.Game.Objects.Orders
 			}
 		}
 
-		public void Reset()
-		{
-			NewFacility = null;
-		}
+		public void Reset() => NewFacility = null;
 	}
 }

--- a/FrEee/Game/Objects/Orders/WarpOrder.cs
+++ b/FrEee/Game/Objects/Orders/WarpOrder.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
@@ -8,6 +8,8 @@ using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Orders
 {
@@ -20,56 +22,39 @@ namespace FrEee.Game.Objects.Orders
 	{
 		public WarpOrder(WarpPoint warpPoint)
 		{
-			Owner = Empire.Current;
-			WarpPoint = warpPoint;
+			owner = Empire.Current;
+			this.warpPoint = warpPoint;
 		}
 
-		public bool ConsumesMovement
-		{
-			get { return true; }
-		}
+		public bool ConsumesMovement => true;
 
-		public Sector Destination
-		{
-			get { return WarpPoint.Target; }
-		}
+		public Sector Destination => WarpPoint.Target;
 
 		public long ID { get; set; }
 
-		public bool IsComplete
-		{
-			get;
-			set;
-		}
+		public bool IsComplete { get; set; }
 
 		public bool IsDisposed { get; set; }
 
 		[DoNotSerialize]
-		public bool LoggedPathfindingError
-		{
-			get;
-			private set;
-		}
+		public bool LoggedPathfindingError { get; private set; }
 
 		/// <summary>
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire Owner { get => owner; set => owner = value; }
 
 		/// <summary>
 		/// The warp point we are using.
 		/// </summary>
 		[DoNotSerialize]
-		public WarpPoint WarpPoint { get { return warpPoint; } set { warpPoint = value; } }
+		public WarpPoint WarpPoint { get => warpPoint; set => warpPoint = value; }
 
 		private GalaxyReference<Empire> owner { get; set; }
 		private GalaxyReference<WarpPoint> warpPoint { get; set; }
 
-		public bool CheckCompletion(IOrderable v)
-		{
-			return IsComplete;
-		}
+		public bool CheckCompletion(IOrderable v) => IsComplete;
 
 		/// <summary>
 		/// Orders are visible only to their owners.
@@ -84,9 +69,7 @@ namespace FrEee.Game.Objects.Orders
 		}
 
 		public IDictionary<PathfinderNode<Sector>, ISet<PathfinderNode<Sector>>> CreateDijkstraMap(IMobileSpaceObject me, Sector start)
-		{
-			return Pathfinder.CreateDijkstraMap(me, start, Destination, false, true);
-		}
+			=> Pathfinder.CreateDijkstraMap(me, start, Destination, false, true);
 
 		public void Dispose()
 		{
@@ -153,11 +136,9 @@ namespace FrEee.Game.Objects.Orders
 		}
 
 		public IEnumerable<Sector> Pathfind(IMobileSpaceObject me, Sector start)
-		{
-			return Pathfinder.Pathfind(me, start, Destination, false, true, me.DijkstraMap);
-		}
+			=> Pathfinder.Pathfind(me, start, Destination, false, true, me.DijkstraMap);
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			// This type does not use client objects, so nothing to do here.
 		}

--- a/FrEee/Game/Objects/Orders/WaypointOrder.cs
+++ b/FrEee/Game/Objects/Orders/WaypointOrder.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.LogMessages;
@@ -7,6 +7,8 @@ using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Orders
 {
@@ -18,8 +20,8 @@ namespace FrEee.Game.Objects.Orders
 	{
 		public WaypointOrder(Waypoint target, bool avoidEnemies)
 		{
-			Owner = Empire.Current;
-			Target = target;
+			owner = Empire.Current;
+			this.target = target;
 			AvoidEnemies = avoidEnemies;
 			// TODO - add flag for "avoid damaging sectors"? but how to specify in UI?
 		}
@@ -29,23 +31,13 @@ namespace FrEee.Game.Objects.Orders
 		/// </summary>
 		public bool AvoidEnemies { get; set; }
 
-		public bool ConsumesMovement
-		{
-			get { return true; }
-		}
+		public bool ConsumesMovement => true;
 
-		public Sector Destination
-		{
-			get { return Target.Sector; }
-		}
+		public Sector? Destination => Target.Sector;
 
 		public long ID { get; set; }
 
-		public bool IsComplete
-		{
-			get;
-			set;
-		}
+		public bool IsComplete { get; set; }
 
 		public bool IsDisposed { get; set; }
 
@@ -59,58 +51,39 @@ namespace FrEee.Game.Objects.Orders
 		/// The empire which issued the order.
 		/// </summary>
 		[DoNotSerialize]
-		public Empire Owner { get { return owner; } set { owner = value; } }
+		public Empire Owner { get => owner; set => owner = value; }
 
 		/// <summary>
 		/// Any pathfinding error that we might have found.
 		/// </summary>
 		[DoNotSerialize]
-		public LogMessage PathfindingError { get; private set; }
+		public LogMessage? PathfindingError { get; private set; }
 
 		/// <summary>
 		/// The target we are pursuing.
 		/// </summary>
 		[DoNotSerialize]
-		public Waypoint Target { get { return target.Value; } set { target = value.ReferViaGalaxy(); } }
+		public Waypoint Target { get => target.Value; set => target = value.ReferViaGalaxy(); }
 
 		/// <summary>
 		/// A verb used to describe this order.
 		/// </summary>
-		public string Verb
-		{
-			get
-			{
-				if (AvoidEnemies)
-					return "navigate to";
-				else
-					return "patrol";
-			}
-		}
+		public string Verb => AvoidEnemies ? "navigate to" : "patrol";
 
 		private GalaxyReference<Empire> owner { get; set; }
 		private GalaxyReference<Waypoint> target { get; set; }
 
-		public bool CheckCompletion(IOrderable v)
-		{
-			return IsComplete;
-		}
+		public bool CheckCompletion(IOrderable v) => IsComplete;
 
 		/// <summary>
 		/// Orders are visible only to their owners.
 		/// </summary>
 		/// <param name="emp"></param>
 		/// <returns></returns>
-		public Visibility CheckVisibility(Empire emp)
-		{
-			if (emp == Owner)
-				return Visibility.Visible;
-			return Visibility.Unknown;
-		}
+		public Visibility CheckVisibility(Empire emp) => emp == Owner ? Visibility.Visible : Visibility.Unknown;
 
 		public IDictionary<PathfinderNode<Sector>, ISet<PathfinderNode<Sector>>> CreateDijkstraMap(IMobileSpaceObject me, Sector start)
-		{
-			return Pathfinder.CreateDijkstraMap(me, start, Destination, AvoidEnemies, true);
-		}
+			=> Pathfinder.CreateDijkstraMap(me, start, Destination, AvoidEnemies, true);
 
 		public void Dispose()
 		{
@@ -191,21 +164,10 @@ namespace FrEee.Game.Objects.Orders
 		/// <param name="sobj">The space object executing the order.</param>
 		/// <param name="start">The start location (need not be the current location, in case there are prior orders queued).</param>
 		/// <returns></returns>
-		public IEnumerable<Sector> Pathfind(IMobileSpaceObject me, Sector start)
-		{
-			return Pathfinder.Pathfind(me, start, Destination, AvoidEnemies, true, me.DijkstraMap);
-		}
+		public IEnumerable<Sector> Pathfind(IMobileSpaceObject me, Sector start) => Pathfinder.Pathfind(me, start, Destination, AvoidEnemies, true, me.DijkstraMap);
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done)
-		{
-			target.ReplaceClientIDs(idmap, done);
-		}
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done) => target.ReplaceClientIDs(idmap, done);
 
-		public override string ToString()
-		{
-			if (Target == null)
-				return "Unknown " + Verb + " order";
-			return Verb.Capitalize() + " " + Target;
-		}
+		public override string ToString() => Target == null ? $"Unknown {Verb} order" : $"{Verb.Capitalize()} {Target}";
 	}
 }

--- a/FrEee/Game/Objects/Space/AsteroidField.cs
+++ b/FrEee/Game/Objects/Space/AsteroidField.cs
@@ -6,6 +6,8 @@ using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Space
 {
 	/// <summary>
@@ -14,27 +16,21 @@ namespace FrEee.Game.Objects.Space
 	[Serializable]
 	public class AsteroidField : StellarObject, ITemplate<AsteroidField>, IMineableSpaceObject, IDataObject
 	{
-		public AsteroidField()
-		{
-			ResourceValue = new ResourceQuantity();
-		}
+		public AsteroidField() => ResourceValue = new ResourceQuantity();
 
-		public override AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.AsteroidField; }
-		}
+		public override AbilityTargets AbilityTarget => AbilityTargets.AsteroidField;
 
 		/// <summary>
 		/// The atmospheric composition (e.g. methane, oxygen, carbon dioxide) of this asteroid field.
 		/// </summary>
-		public string Atmosphere { get; set; }
+		public string? Atmosphere { get; set; }
 
 		public override bool CanBeObscured => true;
 
 		/// <summary>
 		/// Some sort of combat image? Where are these stored anyway?
 		/// </summary>
-		public string CombatTile { get; set; }
+		public string? CombatTile { get; set; }
 
 		public override SafeDictionary<string, object> Data
 		{
@@ -60,19 +56,13 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public double MineralsValue { get { return ResourceValue[Resource.Minerals]; } }
+		public double MineralsValue => ResourceValue[Resource.Minerals];
 
-		public double OrganicsValue { get { return ResourceValue[Resource.Organics]; } }
+		public double OrganicsValue => ResourceValue[Resource.Organics];
 
-		public Empire Owner
-		{
-			get
-			{
-				return null;
-			}
-		}
+		public Empire? Owner => null;
 
-		public double RadioactivesValue { get { return ResourceValue[Resource.Radioactives]; } }
+		public double RadioactivesValue => ResourceValue[Resource.Radioactives];
 
 		/// <summary>
 		/// The resource value of this asteroid field, in %.
@@ -83,14 +73,14 @@ namespace FrEee.Game.Objects.Space
 		/// The PlanetSize.txt entry for this asteroid field's size.
 		/// </summary>
 		[DoNotSerialize]
-		public StellarObjectSize Size { get { return size; } set { size = value; } }
+		public StellarObjectSize Size { get => size; set => size = value; }
 
 		/// <summary>
 		/// The surface composition (e.g. rock, ice, gas) of this asteroid field.
 		/// </summary>
-		public string Surface { get; set; }
+		public string? Surface { get; set; }
 
-		private ModReference<StellarObjectSize> size { get; set; }
+		private ModReference<StellarObjectSize>? size { get; set; }
 
 		/// <summary>
 		/// Just copy the asteroid field's data.

--- a/FrEee/Game/Objects/Space/Fleet.cs
+++ b/FrEee/Game/Objects/Space/Fleet.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Abilities;
 using FrEee.Game.Objects.Civilization;
@@ -14,6 +14,8 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Space
 {
 	/// <summary>
@@ -28,21 +30,12 @@ namespace FrEee.Game.Objects.Space
 			Timestamp = Galaxy.Current?.Timestamp ?? 0;
 		}
 
-		public AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.Fleet; }
-		}
+		public AbilityTargets AbilityTarget => AbilityTargets.Fleet;
 
-		public int Accuracy
-		{
-			get
-			{
-				// TODO - fleet experience
-				return 0;
-			}
-		}
+		// TODO - fleet experience
+		public int Accuracy => 0;
 
-		public IDictionary<Civilization.Race, long> AllPopulation
+		public IDictionary<Race, long> AllPopulation
 		{
 			get
 			{
@@ -82,40 +75,22 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		public bool AreRepeatOrdersEnabled { get; set; }
 
-		public int ArmorHitpoints
-		{
-			get { return Vehicles.Sum(v => v.ArmorHitpoints); }
-		}
+		public int ArmorHitpoints => Vehicles.Sum(v => v.ArmorHitpoints);
 
 		/// <summary>
 		/// Fleets can be nested.
 		/// </summary>
-		public bool CanBeInFleet
-		{
-			get { return true; }
-		}
+		public bool CanBeInFleet => true;
 
 		public bool CanBeObscured => true;
 
-		public bool CanWarp
-		{
-			get { return Vehicles.All(sobj => sobj.CanWarp); }
-		}
+		public bool CanWarp => Vehicles.All(sobj => sobj.CanWarp);
 
-		public Cargo Cargo
-		{
-			get { return Vehicles.OfType<ICargoContainer>().Sum(cc => cc.Cargo); }
-		}
+		public Cargo Cargo => Vehicles.OfType<ICargoContainer>().Sum(cc => cc.Cargo);
 
-		public int CargoStorage
-		{
-			get { return Vehicles.OfType<ICargoContainer>().Sum(cc => cc.CargoStorage); }
-		}
+		public int CargoStorage => Vehicles.OfType<ICargoContainer>().Sum(cc => cc.CargoStorage);
 
-		public IEnumerable<IAbilityObject> Children
-		{
-			get { return Vehicles; }
-		}
+		public IEnumerable<IAbilityObject> Children => Vehicles;
 
 		/// <summary>
 		/// Any combatants contained in this fleet and any subfleets.
@@ -128,7 +103,7 @@ namespace FrEee.Game.Objects.Space
 				{
 					var list = new List<ICombatant>();
 					if (sobj is ICombatant)
-						list.Add((ICombatant)sobj);
+						list.Add(sobj);
 					if (sobj is Fleet)
 						list.AddRange(((Fleet)sobj).Combatants);
 					return list;
@@ -157,50 +132,25 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public Fleet Container
-		{
-			get; set;
-		}
+		public Fleet? Container { get; set; }
 
 		[DoNotSerialize]
-		public IDictionary<PathfinderNode<Sector>, ISet<PathfinderNode<Sector>>> DijkstraMap
-		{
-			get;
-			set;
-		}
+		public IDictionary<PathfinderNode<Sector>, ISet<PathfinderNode<Sector>>>? DijkstraMap { get; set; }
 
-		public int Evasion
-		{
-			get
-			{
-				// TODO - fleet experience
-				return 0;
-			}
-		}
+		// TODO - fleet experience
+		public int Evasion => 0;
 
-		public ResourceQuantity GrossIncome
-		{
-			get { return Vehicles.OfType<IIncomeProducer>().Sum(v => v.GrossIncome()); }
-		}
+		public ResourceQuantity GrossIncome => Vehicles.OfType<IIncomeProducer>().Sum(v => v.GrossIncome());
 
 		/// <summary>
 		/// Fleets share supplies, so if any space object has infinite supplies, the fleet does.
 		/// </summary>
-		public bool HasInfiniteSupplies
-		{
-			get { return Vehicles.ExceptSingle(null).Any(sobj => sobj.HasInfiniteSupplies); }
-		}
+		public bool HasInfiniteSupplies => Vehicles.Any(sobj => sobj.HasInfiniteSupplies);
 
 		/// <summary>
 		/// Chance of hitting each ship in a fleet is equal, so this value is the number of ships in the fleet.
 		/// </summary>
-		public int HitChance
-		{
-			get
-			{
-				return LeafVehicles.Count();
-			}
-		}
+		public int HitChance => LeafVehicles.Count();
 
 		/// <summary>
 		/// The hitpoints of this fleet. Cannot set this property; attempting to do so will throw a NotSupportedException.
@@ -208,20 +158,14 @@ namespace FrEee.Game.Objects.Space
 		[DoNotSerialize(false)]
 		public int Hitpoints
 		{
-			get
-			{
-				return Vehicles.Sum(sobj => sobj.Hitpoints);
-			}
+			get => Vehicles.Sum(sobj => sobj.Hitpoints);
 			set
 			{
 				throw new NotSupportedException("Cannot set fleet hitpoints directly. Try setting the hitpoints of individual ship components.");
 			}
 		}
 
-		public int HullHitpoints
-		{
-			get { return Vehicles.Sum(v => v.HullHitpoints); }
-		}
+		public int HullHitpoints => Vehicles.Sum(v => v.HullHitpoints);
 
 		public Image Icon
 		{
@@ -234,19 +178,9 @@ namespace FrEee.Game.Objects.Space
 
 		public Image Icon32 => Icon.Resize(32);
 
-		public IEnumerable<string> IconPaths
-		{
-			get
-			{
-				return GetImagePaths("Mini");
-			}
-		}
+		public IEnumerable<string> IconPaths => GetImagePaths("Mini");
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
 		public IEnumerable<Ability> IntrinsicAbilities
 		{
@@ -259,28 +193,15 @@ namespace FrEee.Game.Objects.Space
 
 		public bool IsAlive => Vehicles.Any(x => x.IsAlive);
 
-		public bool IsDestroyed
-		{
-			get { return Vehicles.ExceptSingle(null).All(sobj => sobj.IsDestroyed); }
-		}
+		public bool IsDestroyed => Vehicles.All(sobj => sobj.IsDestroyed);
 
 		public bool IsDisposed { get; set; }
 
-		public bool IsIdle
-		{
-			get
-			{
-				return StrategicSpeed > 0 && !Orders.Any() && Container == null || ConstructionQueues.Any(q => q.Eta < 1);
-			}
-		}
+		public bool IsIdle => StrategicSpeed > 0 && !Orders.Any() && Container == null || ConstructionQueues.Any(q => q.Eta < 1);
 
-		public bool IsMemory
-		{
-			get;
-			set;
-		}
+		public bool IsMemory { get; set; }
 
-		public bool IsOurs { get { return Owner == Empire.Current; } }
+		public bool IsOurs => Owner == Empire.Current;
 
 		/// <summary>
 		/// All space vehicles in this fleet and subfleets, but not counting the subfleets themselves.
@@ -304,40 +225,19 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public ResourceQuantity MaintenanceCost
-		{
-			get { return Vehicles.Sum(v => v.MaintenanceCost); }
-		}
+		public ResourceQuantity MaintenanceCost => Vehicles.Sum(v => v.MaintenanceCost);
 
-		public int MaxArmorHitpoints
-		{
-			get { return Vehicles.Sum(v => v.MaxArmorHitpoints); }
-		}
+		public int MaxArmorHitpoints => Vehicles.Sum(v => v.MaxArmorHitpoints);
 
-		public int MaxHitpoints
-		{
-			get { return Vehicles.Sum(sobj => sobj.MaxHitpoints); }
-		}
+		public int MaxHitpoints => Vehicles.Sum(sobj => sobj.MaxHitpoints);
 
-		public int MaxHullHitpoints
-		{
-			get { return Vehicles.Sum(v => v.MaxHullHitpoints); }
-		}
+		public int MaxHullHitpoints => Vehicles.Sum(v => v.MaxHullHitpoints);
 
-		public int MaxNormalShields
-		{
-			get { return Vehicles.Sum(sobj => sobj.MaxNormalShields); }
-		}
+		public int MaxNormalShields => Vehicles.Sum(sobj => sobj.MaxNormalShields);
 
-		public int MaxPhasedShields
-		{
-			get { return Vehicles.Sum(sobj => sobj.MaxPhasedShields); }
-		}
+		public int MaxPhasedShields => Vehicles.Sum(sobj => sobj.MaxPhasedShields);
 
-		public int MaxShieldHitpoints
-		{
-			get { return Vehicles.Sum(v => v.MaxShieldHitpoints); }
-		}
+		public int MaxShieldHitpoints => Vehicles.Sum(v => v.MaxShieldHitpoints);
 
 		/// <summary>
 		/// Fleets can't fire on enemies directly; the contained ships do.
@@ -346,18 +246,11 @@ namespace FrEee.Game.Objects.Space
 
 		public double MerchantsRatio => Owner.HasAbility("No Spaceports") ? 1.0 : 0.0;
 
-		public int MineralsMaintenance
-		{
-			get { return MaintenanceCost[Resource.Minerals]; }
-		}
+		public int MineralsMaintenance => MaintenanceCost[Resource.Minerals];
 
 		public int MovementRemaining { get; set; }
 
-		public string Name
-		{
-			get;
-			set;
-		}
+		public string? Name { get; set; }
 
 		/// <summary>
 		/// The normal shields of this fleet. Cannot set this property; attempting to do so will throw a NotSupportedException.
@@ -365,10 +258,7 @@ namespace FrEee.Game.Objects.Space
 		[DoNotSerialize(false)]
 		public int NormalShields
 		{
-			get
-			{
-				return Vehicles.Sum(sobj => sobj.NormalShields);
-			}
+			get => Vehicles.Sum(sobj => sobj.NormalShields);
 			set
 			{
 				throw new NotSupportedException("Cannot set fleet shields directly. Try setting the shields of individual ships.");
@@ -377,15 +267,13 @@ namespace FrEee.Game.Objects.Space
 
 		public IList<IOrder> Orders { get; private set; }
 
-		public int OrganicsMaintenance
-		{
-			get { return MaintenanceCost[Resource.Organics]; }
-		}
+		public int OrganicsMaintenance => MaintenanceCost[Resource.Organics];
 
+		// assume all vehicles have the same owner
 		[DoNotSerialize]
-		public Empire Owner
+		public Empire? Owner
 		{
-			get { return Vehicles.ExceptSingle(null).FirstOrDefault()?.Owner; } // assume all vehicles have the same owner
+			get => Vehicles.FirstOrDefault()?.Owner;
 			set
 			{
 				foreach (var v in Vehicles)
@@ -425,10 +313,7 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public long PopulationStorageFree
-		{
-			get { return 0L; }
-		}
+		public long PopulationStorageFree => 0L;
 
 		public Image Portrait
 		{
@@ -439,33 +324,18 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public IEnumerable<string> PortraitPaths
-		{
-			get
-			{
-				return GetImagePaths("Portrait");
-			}
-		}
+		public IEnumerable<string> PortraitPaths => GetImagePaths("Portrait");
 
-		public int RadioactivesMaintenance
-		{
-			get { return MaintenanceCost[Resource.Radioactives]; }
-		}
+		public int RadioactivesMaintenance => MaintenanceCost[Resource.Radioactives];
 
-		public ResourceQuantity RemoteMiningIncomePercentages
-		{
-			get { return Owner.PrimaryRace.IncomePercentages; }
-		}
+		public ResourceQuantity? RemoteMiningIncomePercentages => Owner?.PrimaryRace?.IncomePercentages;
 
 		/// <summary>
 		/// Fleets have no resource value.
 		/// </summary>
-		public ResourceQuantity ResourceValue
-		{
-			get { return new ResourceQuantity(); }
-		}
+		public ResourceQuantity ResourceValue => new ResourceQuantity();
 
-		public Sector Sector
+		public Sector? Sector
 		{
 			get
 			{
@@ -492,54 +362,27 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public int ShieldHitpoints
-		{
-			get { return Vehicles.Sum(v => v.ShieldHitpoints); }
-		}
+		public int ShieldHitpoints => Vehicles.Sum(v => v.ShieldHitpoints);
 
-		public int Size
-		{
-			get { return Vehicles.ExceptSingle((IMobileSpaceObject)null).Sum(v => v.Size); }
-		}
+		public int Size => Vehicles.Sum(v => v.Size);
 
-		public ResourceQuantity StandardIncomePercentages
-		{
-			get { return Owner.PrimaryRace.IncomePercentages; }
-		}
+		public ResourceQuantity? StandardIncomePercentages => Owner?.PrimaryRace?.IncomePercentages;
 
-		public StarSystem StarSystem
-		{
-			get { return this.FindStarSystem(); }
-		}
+		public StarSystem StarSystem => this.FindStarSystem();
 
 		/// <summary>
 		/// Resources stored in this fleet.
 		/// Note that modifying this value will have no effect on the individual vehicles in the fleet;
 		/// we just don't have a handy read only resource quantity type.
 		/// </summary>
-		public ResourceQuantity StoredResources
-		{
-			get
-			{
-				return Vehicles.Sum(v => v.StoredResources);
-			}
-		}
+		public ResourceQuantity StoredResources => Vehicles.Sum(v => v.StoredResources);
 
-		public int StrategicSpeed
-		{
-			get { return Vehicles.MinOrDefault(sobj => sobj.StrategicSpeed); }
-		}
+		public int StrategicSpeed => Vehicles.MinOrDefault(sobj => sobj.StrategicSpeed);
 
 		/// <summary>
 		/// The amount of supply which this fleet can store.
 		/// </summary>
-		public int SupplyCapacity
-		{
-			get
-			{
-				return this.GetAbilityValue("Supply Storage").ToInt();
-			}
-		}
+		public int SupplyCapacity => this.GetAbilityValue("Supply Storage").ToInt();
 
 		[DoNotSerialize(false)]
 		public int SupplyRemaining
@@ -566,7 +409,7 @@ namespace FrEee.Game.Objects.Space
 						sobj.SupplyRemaining = 0;
 						continue;
 					}
-					var amount = (int)Math.Floor((double)sobj.SupplyStorage / (double)storage * available);
+					var amount = (int)Math.Floor(sobj.SupplyStorage / (double)storage * available);
 					sobj.SupplyRemaining = amount;
 					spent += amount;
 				}
@@ -575,7 +418,7 @@ namespace FrEee.Game.Objects.Space
 				{
 					while (roundingError > 0)
 					{
-						var sobj2 = Vehicles.WithMin(sobj => (double)sobj.SupplyRemaining / (double)sobj.SupplyStorage).PickRandom();
+						var sobj2 = Vehicles.WithMin(sobj => sobj.SupplyRemaining / (double)sobj.SupplyStorage).PickRandom();
 						sobj2.SupplyRemaining += 1;
 						roundingError -= 1;
 					}
@@ -586,29 +429,14 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public int SupplyStorage
-		{
-			get { return Vehicles.Sum(sobj => sobj.SupplyStorage); }
-		}
+		public int SupplyStorage => Vehicles.Sum(sobj => sobj.SupplyStorage);
 
-		public double TimePerMove
-		{
-			get
-			{
-				if (!Vehicles.Any())
-					return double.PositiveInfinity;
-				return Vehicles.Max(sobj => sobj.TimePerMove);
-			}
-		}
+		public double TimePerMove => !Vehicles.Any() ? double.PositiveInfinity : Vehicles.Max(sobj => sobj.TimePerMove);
 
 		public double Timestamp { get; set; }
 
 		[DoNotSerialize]
-		public double TimeToNextMove
-		{
-			get;
-			set;
-		}
+		public double TimeToNextMove { get; set; }
 
 		/// <summary>
 		/// The space objects in the fleet.
@@ -616,20 +444,14 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		public GalaxyReferenceSet<IMobileSpaceObject> Vehicles { get; private set; }
 
-		public IEnumerable<Component> Weapons
-		{
-			get { return Vehicles.SelectMany(sobj => sobj.Weapons); }
-		}
+		public IEnumerable<Component> Weapons => Vehicles.SelectMany(sobj => sobj.Weapons);
 
 		/// <summary>
 		/// Fleets cannot be directly targeted by weapons. Target the individual ships instead.
 		/// </summary>
-		public WeaponTargets WeaponTargetType
-		{
-			get { return WeaponTargets.None; }
-		}
+		public WeaponTargets WeaponTargetType => WeaponTargets.None;
 
-		private Sector sector;
+		private Sector? sector;
 
 		public void AddOrder(IOrder order)
 		{
@@ -666,10 +488,7 @@ namespace FrEee.Game.Objects.Space
 				v.BurnMovementSupplies();
 		}
 
-		public bool CanTarget(ITargetable target)
-		{
-			return Vehicles.Any(sobj => sobj.CanTarget(target));
-		}
+		public bool CanTarget(ITargetable target) => Vehicles.Any(sobj => sobj.CanTarget(target));
 
 		/// <summary>
 		/// Fleets are as visible as their most visible space object. Not that the others will actually be that visible...
@@ -691,7 +510,7 @@ namespace FrEee.Game.Objects.Space
 			if (IsDisposed)
 				return;
 			IsDisposed = true;
-			foreach (var v in Vehicles.ExceptSingle(null))
+			foreach (var v in Vehicles)
 				v.Container = null;
 			Vehicles.Clear();
 			Galaxy.Current.UnassignID(this);
@@ -703,15 +522,12 @@ namespace FrEee.Game.Objects.Space
 
 		public bool ExecuteOrders()
 		{
-			if (!Vehicles.ExceptSingle(null).Any())
+			if (!Vehicles.Any())
 				return false; // fleets with no vehicles can't execute orders
 			return this.ExecuteMobileSpaceObjectOrders();
 		}
 
-		public bool IsHostileTo(Empire emp)
-		{
-			return Owner != null && Owner.IsEnemyOf(emp, StarSystem);
-		}
+		public bool IsHostileTo(Empire emp) => Owner != null && Owner.IsEnemyOf(emp, StarSystem);
 
 		public bool IsObsoleteMemory(Empire emp)
 		{
@@ -724,7 +540,7 @@ namespace FrEee.Game.Objects.Space
 		{
 			if (!(order is IOrder))
 				throw new InvalidOperationException("Fleets can only accept orders of type IOrder.");
-			var o = (IOrder)order;
+			var o = order;
 			var newpos = Orders.IndexOf(o) + delta;
 			Orders.Remove(o);
 			if (newpos < 0)
@@ -759,10 +575,10 @@ namespace FrEee.Game.Objects.Space
 		{
 			if (!(order is IOrder))
 				return; // order can't exist here anyway
-			Orders.Remove((IOrder)order);
+			Orders.Remove(order);
 		}
 
-		public long RemovePopulation(Civilization.Race race, long amount)
+		public long RemovePopulation(Race race, long amount)
 		{
 			foreach (var ct in Vehicles.OfType<ICargoTransferrer>())
 			{
@@ -789,7 +605,7 @@ namespace FrEee.Game.Objects.Space
 			return amount;
 		}
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();
@@ -841,7 +657,7 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// Assigns damage to a random ship in the fleet. If damage is left over, it leaks to the next ship.
 		/// </summary>
-		public int TakeDamage(Hit hit, PRNG dice = null)
+		public int TakeDamage(Hit hit, PRNG? dice = null)
 		{
 			var vs = LeafVehicles.Shuffle().ToList();
 			var dmg = hit.NominalDamage;
@@ -855,10 +671,7 @@ namespace FrEee.Game.Objects.Space
 			return dmg;
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name ?? string.Empty;
 
 		/// <summary>
 		/// Remove any invalid objects from the fleet and any valid subfleets.
@@ -869,19 +682,19 @@ namespace FrEee.Game.Objects.Space
 		/// * Space objects that are not located in the same sector as this fleet
 		/// * Space objects that are destroyed
 		/// </summary>
-		public void Validate(ICollection<Fleet> ancestors = null)
+		public void Validate(ICollection<Fleet>? ancestors = null)
 		{
 			if (ancestors == null)
 				ancestors = new List<Fleet>();
 			ancestors.Add(this);
 			foreach (var sobj in Vehicles.ToArray())
 			{
-				if (sobj == null || sobj.Owner != Owner || (sobj is Fleet && ancestors.Contains((Fleet)sobj)) || sobj.Sector != Sector || sobj.IsDestroyed)
+				if (sobj.Owner != Owner || (sobj is Fleet && ancestors.Contains((Fleet)sobj)) || sobj.Sector != Sector || sobj.IsDestroyed)
 					Vehicles.Remove(sobj);
 				else if (sobj is Fleet)
 					((Fleet)sobj).Validate(ancestors);
 			}
-			if (!Vehicles.ExceptSingle(null).Any())
+			if (!Vehicles.Any())
 				Dispose();
 		}
 

--- a/FrEee/Game/Objects/Space/Galaxy.cs
+++ b/FrEee/Game/Objects/Space/Galaxy.cs
@@ -132,7 +132,7 @@ namespace FrEee.Game.Objects.Space
         /// <summary>
         /// The empires participating in the game.
         /// </summary>
-        public IList<Empire> Empires { get; private set; }
+        public IList<Empire?> Empires { get; private set; }
 
         /// <summary>
         /// Per mille chance of a random event occurring, per turn, per player.

--- a/FrEee/Game/Objects/Space/ObjectLocation.cs
+++ b/FrEee/Game/Objects/Space/ObjectLocation.cs
@@ -2,6 +2,8 @@ using FrEee.Utility;
 using System;
 using System.Drawing;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Space
 {
 	/// <summary>

--- a/FrEee/Game/Objects/Space/Planet.cs
+++ b/FrEee/Game/Objects/Space/Planet.cs
@@ -15,6 +15,8 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Space
 {
 	/// <summary>
@@ -79,7 +81,7 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// The atmospheric composition (e.g. methane, oxygen, carbon dioxide) of this planet.
 		/// </summary>
-		public string Atmosphere { get; set; }
+		public string? Atmosphere { get; set; }
 
 		public override bool CanBeInFleet => false;
 
@@ -91,7 +93,7 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		public override bool CanWarp => true;
 
-		public Cargo Cargo => Colony?.Cargo;
+		public Cargo? Cargo => Colony?.Cargo;
 
 		public Progress CargoFill => new Progress(Colony?.Cargo.Size ?? 0, MaxCargo);
 
@@ -126,13 +128,13 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// The colony on this planet, if any.
 		/// </summary>
-		public Colony Colony { get; set; }
+		public Colony? Colony { get; set; }
 
 		public double CombatSpeed => 0;
 
-		public override ConstructionQueue ConstructionQueue => Colony?.ConstructionQueue;
+		public override ConstructionQueue? ConstructionQueue => Colony?.ConstructionQueue;
 
-		public Fleet Container { get; set; }
+		public Fleet? Container { get; set; }
 
 		public override SafeDictionary<string, object> Data
 		{
@@ -158,16 +160,12 @@ namespace FrEee.Game.Objects.Space
 				ModID = value[nameof(ModID)].Default<string>();
 				ResourceValue = value[nameof(ResourceValue)].Default(new ResourceQuantity());
 				Colony = value[nameof(Colony)].Default<Colony>();
-				Orders = value[nameof(Orders)].Default(new List<IOrder>());
+				Orders = value[nameof(Orders)].Default(new List<IOrder?>());
 			}
 		}
 
 		[DoNotSerialize]
-		public IDictionary<PathfinderNode<Sector>, ISet<PathfinderNode<Sector>>> DijkstraMap
-		{
-			get;
-			set;
-		}
+		public IDictionary<PathfinderNode<Sector>, ISet<PathfinderNode<Sector>>>? DijkstraMap { get; set; }
 
 		public int Evasion
 		{
@@ -224,7 +222,7 @@ namespace FrEee.Game.Objects.Space
 			{
 				if (Colony == null)
 					return 0;
-				return Cargo.Hitpoints + Colony.Facilities.Sum(f => f.Hitpoints) + (int)AllPopulation.Sum(kvp => kvp.Value * Mod.Current.Settings.PopulationHitpoints);
+				return (Cargo?.Hitpoints ?? 0) + Colony.Facilities.Sum(f => f.Hitpoints) + (int)AllPopulation.Sum(kvp => kvp.Value * Mod.Current.Settings.PopulationHitpoints);
 			}
 			set
 			{
@@ -233,9 +231,7 @@ namespace FrEee.Game.Objects.Space
 		}
 
 		public int HullHitpoints
-		{
-			get { return Colony == null ? 0 : (Colony.Facilities.Sum(f => f.Hitpoints) + (int)(Colony.Population.Sum(kvp => kvp.Value) * Mod.Current.Settings.PopulationHitpoints) + Cargo.HullHitpoints); }
-		}
+			=> Colony == null ? 0 : (Colony.Facilities.Sum(f => f.Hitpoints) + (int)(Colony.Population.Sum(kvp => kvp.Value) * Mod.Current.Settings.PopulationHitpoints) + Cargo?.HullHitpoints ?? 0);
 
 		public override Image Icon
 		{
@@ -283,14 +279,12 @@ namespace FrEee.Game.Objects.Space
 			{
 				if (Colony == null)
 					return 0;
-				return Cargo.MaxHitpoints + Colony.Facilities.Sum(f => f.MaxHitpoints);
+				return (Cargo?.MaxHitpoints ?? 0) + Colony.Facilities.Sum(f => f.MaxHitpoints);
 			}
 		}
 
 		public int MaxHullHitpoints
-		{
-			get { return Colony == null ? 0 : (Colony.Facilities.Sum(f => f.MaxHitpoints) + (int)(Colony.Population.Sum(kvp => kvp.Value) * Mod.Current.Settings.PopulationHitpoints) + Cargo.MaxHullHitpoints); }
-		}
+			=> Colony == null ? 0 : (Colony.Facilities.Sum(f => f.MaxHitpoints) + (int)(Colony.Population.Sum(kvp => kvp.Value) * Mod.Current.Settings.PopulationHitpoints) + (Cargo?.MaxHullHitpoints ?? 0));
 
 		public int MaxNormalShields
 		{
@@ -370,7 +364,7 @@ namespace FrEee.Game.Objects.Space
 
 		public int NormalShields { get; set; }
 
-		public IList<IOrder> Orders { get; private set; }
+		public IList<IOrder?> Orders { get; private set; }
 
 		public int OrganicsIncome => this.GrossIncome()[Resource.Organics];
 
@@ -379,7 +373,7 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// The empire which has a colony on this planet, if any.
 		/// </summary>
-		public Empire Owner
+		public Empire? Owner
 		{
 			get => Colony?.Owner;
 			set
@@ -560,7 +554,7 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// The surface composition (e.g. rock, ice, gas) of this planet.
 		/// </summary>
-		public string Surface { get; set; }
+		public string? Surface { get; set; }
 
 		/// <summary>
 		/// Planets can't currently move, but they can execute orders at the end of the turn.
@@ -588,9 +582,9 @@ namespace FrEee.Game.Objects.Space
 		/// Used for naming.
 		/// </summary>
 		[DoNotSerialize]
-		internal Planet MoonOf { get; set; }
+		internal Planet? MoonOf { get; set; }
 
-		private ModReference<StellarObjectSize> size { get; set; }
+		private ModReference<StellarObjectSize>? size { get; set; }
 
 		public void AddOrder(IOrder order)
 		{
@@ -618,7 +612,7 @@ namespace FrEee.Game.Objects.Space
 		{
 			if (this.CargoStorageFree() >= unit.Design.Hull.Size)
 			{
-				Colony.Cargo.Units.Add(unit);
+				Colony?.Cargo.Units.Add(unit);
 				return true;
 			}
 			return false;
@@ -686,7 +680,7 @@ namespace FrEee.Game.Objects.Space
 		/// <param name="img"></param>
 		public void DrawPopulationBars(Image img, int? expectedSize = null)
 		{
-			if (Colony != null)
+			if (Colony != null && Colony.Owner != null)
 			{
 				// draw population bar
 				var g = Graphics.FromImage(img);
@@ -741,10 +735,10 @@ namespace FrEee.Game.Objects.Space
 			if (Colony == null && Empire.Current != null && Empire.Current.UnlockedItems.OfType<ComponentTemplate>().Where(c => c.HasAbility(ColonizationAbilityName)).Any())
 			{
 				Brush brush;
-				if (Atmosphere == Empire.Current.PrimaryRace.NativeAtmosphere)
+				if (Atmosphere == Empire.Current.PrimaryRace?.NativeAtmosphere)
 					brush = Brushes.Green;
 				else if (
-					Empire.Current.ColonizedPlanets.Any(p => p.Colony.Population.Any(kvp => kvp.Key.NativeAtmosphere == Atmosphere)) ||
+					Empire.Current.ColonizedPlanets.Any(p => p.Colony!.Population.Any(kvp => kvp.Key.NativeAtmosphere == Atmosphere)) ||
 					Empire.Current.OwnedSpaceObjects.OfType<ICargoContainer>().Any(cc => cc.Cargo.Population.Any(kvp => kvp.Key.NativeAtmosphere == Atmosphere))
 					)
 					brush = Brushes.Yellow;
@@ -827,7 +821,7 @@ namespace FrEee.Game.Objects.Space
 		{
 			if (order != null && !(order is IOrder))
 				return; // order can't exist here anyway
-			Orders.Remove((IOrder)order);
+			Orders.Remove(order);
 		}
 
 		public long RemovePopulation(Race race, long amount)
@@ -845,7 +839,7 @@ namespace FrEee.Game.Objects.Space
 
 		public bool RemoveUnit(IUnit unit)
 		{
-			if (Colony.Cargo.Units.Contains(unit))
+			if (Colony?.Cargo.Units.Contains(unit) ?? false)
 			{
 				Colony.Cargo.Units.Remove(unit);
 				return true;
@@ -907,7 +901,7 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public int TakeDamage(Hit hit, PRNG dice = null)
+		public int TakeDamage(Hit hit, PRNG? dice = null)
 		{
 			var damage = hit.NominalDamage;
 
@@ -928,7 +922,7 @@ namespace FrEee.Game.Objects.Space
 				if (num == 0)
 					damage = TakePopulationDamage(hit, dice);
 				else if (num == 1)
-					damage = Cargo.TakeDamage(hit, dice);
+					damage = Cargo?.TakeDamage(hit, dice) ?? damage;
 				else if (num == 2)
 					damage = TakeFacilityDamage(hit, dice);
 				hit = new Hit(hit.Shot, this, damage);
@@ -937,11 +931,11 @@ namespace FrEee.Game.Objects.Space
 			}
 
 			// if planet was completely glassed, remove the colony
-			if (!Colony.Population.Any(p => p.Value > 0) && !Cargo.Units.Any() && !Cargo.Population.Any(p => p.Value > 0) && !Colony.Facilities.Any())
+			if (!Colony.Population.Any(p => p.Value > 0) && (Cargo is null || (!Cargo.Units.Any() && !Cargo.Population.Any(p => p.Value > 0))) && !Colony.Facilities.Any())
 			{
 				if (Colony.IsHomeworld)
-					Colony.Owner.TriggerHappinessChange(hm => hm.OurHomeworldLost);
-				Colony.Owner.TriggerHappinessChange(hm => hm.OurPlanetLost);
+					Colony.Owner?.TriggerHappinessChange(hm => hm.OurHomeworldLost);
+				Colony.Owner?.TriggerHappinessChange(hm => hm.OurPlanetLost);
 				Colony.Dispose();
 			}
 
@@ -952,7 +946,7 @@ namespace FrEee.Game.Objects.Space
 			return damage;
 		}
 
-		public void TakePopulationDamage(int popFactorsKilled, PRNG dice = null)
+		public void TakePopulationDamage(int popFactorsKilled, PRNG? dice = null)
 		{
 			if (Colony == null)
 				return;
@@ -973,7 +967,7 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		private int TakeFacilityDamage(Hit hit, PRNG dice = null)
+		private int TakeFacilityDamage(Hit hit, PRNG? dice = null)
 		{
 			if (Colony == null)
 				return hit.NominalDamage;
@@ -985,7 +979,7 @@ namespace FrEee.Game.Objects.Space
 				{
 					// skip facilities that are completely pierced by this hit
 					var hit2 = new Hit(hit.Shot, f, damage);
-					return hit2.Shot.DamageType.ComponentPiercing.Evaluate(hit2) < 100;
+					return hit2.Shot?.DamageType.ComponentPiercing.Evaluate(hit2) < 100;
 				}).ToDictionary(f => f, f => f.HitChance).PickWeighted(dice);
 				if (facil == null)
 					break; // no more facilities to hit
@@ -995,7 +989,7 @@ namespace FrEee.Game.Objects.Space
 			return damage;
 		}
 
-		private int TakePopulationDamage(Hit hit, PRNG dice = null)
+		private int TakePopulationDamage(Hit hit, PRNG? dice = null)
 		{
 			if (Colony == null)
 				return hit.NominalDamage;
@@ -1010,7 +1004,7 @@ namespace FrEee.Game.Objects.Space
 					break; // no more population
 				double popHPPerPerson = Mod.Current.Settings.PopulationHitpoints;
 				// TODO - don't ceiling the popKilled, just stack it up
-				int popKilled = (int)Math.Ceiling(hit.Shot.DamageType.PopulationDamage.Evaluate(hit.Shot) / 100 / popHPPerPerson);
+				int popKilled = (int)Math.Ceiling((hit.Shot?.DamageType.PopulationDamage.Evaluate(hit.Shot) ?? 0) / 100 / popHPPerPerson);
 				totalPopKilled += popKilled;
 				Colony.Population[race] -= popKilled;
 				if (Colony.Population[race] < 0)
@@ -1026,7 +1020,7 @@ namespace FrEee.Game.Objects.Space
 
 		public Progress AngerProgress => new Progress(Colony?.AverageAnger ?? 0, Mod.Current.Settings.MaxAnger);
 
-		public IEnumerable<Component> Components => Cargo.Units.OfType<WeaponPlatform>().SelectMany(q => q.Components);
+		public IEnumerable<Component>? Components => Cargo?.Units.OfType<WeaponPlatform>().SelectMany(q => q.Components);
 
 		public bool FillsCombatTile => true;
 	}

--- a/FrEee/Game/Objects/Space/Sector.cs
+++ b/FrEee/Game/Objects/Space/Sector.cs
@@ -181,7 +181,7 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		/// <param name="emp"></param>
 		/// <returns></returns>
-		public bool IsExploredBy(Empire emp)
+		public bool IsExploredBy(Empire? emp)
 		{
 			if (StarSystem == null)
 				return false;

--- a/FrEee/Game/Objects/Space/Sector.cs
+++ b/FrEee/Game/Objects/Space/Sector.cs
@@ -10,6 +10,8 @@ using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Space
 {
 	/// <summary>
@@ -20,94 +22,47 @@ namespace FrEee.Game.Objects.Space
 	{
 		public Sector(StarSystem starSystem, Point coordinates)
 		{
-			StarSystem = starSystem;
+			this.starSystem = starSystem;
 			Coordinates = coordinates;
 		}
 
-		public AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.Sector; }
-		}
+		public AbilityTargets AbilityTarget => AbilityTargets.Sector;
 
 		/// <summary>
 		/// Sectors don't contain population. (They kind of die in space...)
 		/// </summary>
-		public IDictionary<Race, long> AllPopulation
-		{
-			get { return new Dictionary<Race, long>(); }
-		}
+		public IDictionary<Race, long> AllPopulation => new Dictionary<Race, long>();
 
-		public IEnumerable<IUnit> AllUnits
-		{
-			get { return StarSystem.SpaceObjectLocations.Where(l => l.Location == Coordinates).Select(l => l.Item).OfType<IUnit>().ToList(); }
-		}
+		public IEnumerable<IUnit> AllUnits => StarSystem.SpaceObjectLocations.Where(l => l.Location == Coordinates).Select(l => l.Item).OfType<IUnit>().ToList();
 
-		public Cargo Cargo
-		{
-			get
-			{
-				// TODO - implement sector cargo once we have unit groups
-				return new Cargo();
-			}
-		}
+		// TODO - implement sector cargo once we have unit groups
+		public Cargo Cargo => new Cargo();
 
 		/// <summary>
 		/// Sectors can contain practically infinite cargo.
 		/// </summary>
-		public int CargoStorage
-		{
-			get { return int.MaxValue; }
-		}
+		public int CargoStorage => int.MaxValue;
 
-		public IEnumerable<IAbilityObject> Children
-		{
-			get { return SpaceObjects; }
-		}
+		public IEnumerable<IAbilityObject> Children => SpaceObjects;
 
 		public Point Coordinates { get; set; }
 
-		public Image Icon
-		{
-			get
-			{
-				return SpaceObjects.Largest()?.Icon ?? StarSystem?.Icon;
-			}
-		}
+		public Image? Icon => SpaceObjects.Largest()?.Icon ?? StarSystem?.Icon;
 
 		public Image Icon32 => Icon.Resize(32);
 
-		public IEnumerable<string> IconPaths
-		{
-			get
-			{
-				return SpaceObjects.Largest()?.IconPaths ?? StarSystem?.IconPaths;
-			}
-		}
+		public IEnumerable<string>? IconPaths => SpaceObjects.Largest()?.IconPaths ?? StarSystem?.IconPaths;
 
 		public IEnumerable<Ability> IntrinsicAbilities
 		{
 			get { yield break; }
 		}
 
-		public bool IsContested
-		{
-			get
-			{
-				return SpaceObjects.Select(sobj => sobj.Owner).Distinct().ExceptSingle((Empire)null).Count() > 1;
-			}
-		}
+		public bool IsContested => SpaceObjects.Select(sobj => sobj.Owner).Distinct().ExceptSingle((Empire)null).Count() > 1;
 
-		public string Name
-		{
-			get
-			{
-				if (StarSystem == null)
-					return "(Unexplored)";
-				return StarSystem + " (" + Coordinates.X + ", " + Coordinates.Y + ")";
-			}
-		}
+		public string Name => StarSystem == null ? "(Unexplored)" : $"{StarSystem} ({Coordinates.X}, {Coordinates.Y})";
 
-		public Empire Owner
+		public Empire? Owner
 		{
 			get
 			{
@@ -126,26 +81,11 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public long PopulationStorageFree
-		{
-			get { return 0; }
-		}
+		public long PopulationStorageFree => 0;
 
-		public Image Portrait
-		{
-			get
-			{
-				return SpaceObjects.Largest()?.Portrait ?? StarSystem?.Portrait;
-			}
-		}
+		public Image? Portrait => SpaceObjects.Largest()?.Portrait ?? StarSystem?.Portrait;
 
-		public IEnumerable<string> PortraitPaths
-		{
-			get
-			{
-				return SpaceObjects.Largest()?.PortraitPaths ?? StarSystem?.PortraitPaths;
-			}
-		}
+		public IEnumerable<string>? PortraitPaths => SpaceObjects.Largest()?.PortraitPaths ?? StarSystem?.PortraitPaths;
 
 		[DoNotSerialize(false)]
 		Sector ILocated.Sector
@@ -171,29 +111,23 @@ namespace FrEee.Game.Objects.Space
 		}
 
 		[DoNotSerialize]
-		public StarSystem StarSystem { get { return starSystem; } set { starSystem = value; } }
+		public StarSystem StarSystem { get => starSystem; set => starSystem = value; }
 
 		private GalaxyReference<StarSystem> starSystem { get; set; }
 
-		public static bool operator !=(Sector s1, Sector s2)
-		{
-			return !(s1 == s2);
-		}
+		public static bool operator !=(Sector? s1, Sector? s2) => !(s1 == s2);
 
-		public static bool operator ==(Sector s1, Sector s2)
+		public static bool operator ==(Sector? s1, Sector? s2)
 		{
 			if (s1.IsNull() && s2.IsNull())
 				return true;
 			if (s1.IsNull() || s2.IsNull())
 				return false;
-			return s1.starSystem == s2.starSystem && s1.Coordinates == s2.Coordinates;
+			return s1?.starSystem == s2?.starSystem && s1?.Coordinates == s2?.Coordinates;
 		}
 
-		public long AddPopulation(Race race, long amount)
-		{
-			// population jettisoned into space just disappears without a trace...
-			return 0;
-		}
+		// population jettisoned into space just disappears without a trace...
+		public long AddPopulation(Race race, long amount) => 0;
 
 		public bool AddUnit(IUnit unit)
 		{
@@ -224,7 +158,7 @@ namespace FrEee.Game.Objects.Space
 			throw new NotImplementedException();
 		}
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
 			// TODO - upgrade equals to use "as" operator
 			if (obj is Sector)
@@ -315,7 +249,7 @@ namespace FrEee.Game.Objects.Space
 			return false;
 		}
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();

--- a/FrEee/Game/Objects/Space/Star.cs
+++ b/FrEee/Game/Objects/Space/Star.cs
@@ -5,6 +5,8 @@ using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Space
 {
 	/// <summary>
@@ -15,27 +17,24 @@ namespace FrEee.Game.Objects.Space
 	{
 		// TODO - do stars in SE4 have a size property?
 
-		public override AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.Star; }
-		}
+		public override AbilityTargets AbilityTarget => AbilityTargets.Star;
 
 		/// <summary>
 		/// The age of this star. (For flavor)
 		/// </summary>
-		public string Age { get; set; }
+		public string? Age { get; set; }
 
 		/// <summary>
 		/// The brightness of this star. (For flavor)
 		/// </summary>
-		public string Brightness { get; set; }
+		public string? Brightness { get; set; }
 
 		public override bool CanBeObscured => false;
 
 		/// <summary>
 		/// The color of this star. (For flavor)
 		/// </summary>
-		public string Color { get; set; }
+		public string? Color { get; set; }
 
 		public override SafeDictionary<string, object> Data
 		{
@@ -64,13 +63,7 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		public bool IsDestroyed { get; set; }
 
-		public Empire Owner
-		{
-			get
-			{
-				return null;
-			}
-		}
+		public Empire? Owner => null;
 
 		/// <summary>
 		/// Detonates this star. All space vehicles in the system will be destroyed and all planets will be converted to asteroid fields.

--- a/FrEee/Game/Objects/Space/StarSystem.cs
+++ b/FrEee/Game/Objects/Space/StarSystem.cs
@@ -32,7 +32,7 @@ namespace FrEee.Game.Objects.Space
 			Radius = radius;
 			Abilities = new List<Ability>();
 			SpaceObjectLocations = new HashSet<ObjectLocation<ISpaceObject>>();
-			ExploredByEmpires = new HashSet<Empire>();
+			ExploredByEmpires = new HashSet<Empire?>();
 		}
 
 		/// <summary>

--- a/FrEee/Game/Objects/Space/StarSystem.cs
+++ b/FrEee/Game/Objects/Space/StarSystem.cs
@@ -96,7 +96,7 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// Empires which have explored this star system.
 		/// </summary>
-		public ICollection<Empire> ExploredByEmpires { get; private set; }
+		public ICollection<Empire?> ExploredByEmpires { get; private set; }
 
 		public Image? Icon => BackgroundImage;
 

--- a/FrEee/Game/Objects/Space/StarSystem.cs
+++ b/FrEee/Game/Objects/Space/StarSystem.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Abilities;
@@ -12,6 +11,8 @@ using FrEee.Modding;
 using FrEee.Modding.Templates;
 using FrEee.Utility;
 using FrEee.Utility.Extensions;
+
+#nullable enable
 
 namespace FrEee.Game.Objects.Space
 {
@@ -39,12 +40,9 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		public IList<Ability> Abilities { get; private set; }
 
-		public AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.StarSystem; }
-		}
+		public AbilityTargets AbilityTarget => AbilityTargets.StarSystem;
 
-		public Image BackgroundImage
+		public Image? BackgroundImage
 		{
 			get
 			{
@@ -61,7 +59,7 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// The path to the background image, relative to Pictures/Systems.
 		/// </summary>
-		public string BackgroundImagePath { get; set; }
+		public string? BackgroundImagePath { get; set; }
 
 		public IEnumerable<IAbilityObject> Children
 		{
@@ -83,15 +81,12 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// The description of this star system.
 		/// </summary>
-		public string Description { get; set; }
+		public string? Description { get; set; }
 
 		/// <summary>
 		/// The number of sectors across the star system.
 		/// </summary>
-		public int Diameter
-		{
-			get { return Math.Max(0, Radius * 2 + 1); }
-		}
+		public int Diameter => Math.Max(0, Radius * 2 + 1);
 
 		/// <summary>
 		/// If true, empire homeworlds can be located in this system.
@@ -103,39 +98,19 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		public ICollection<Empire> ExploredByEmpires { get; private set; }
 
-		public Image Icon
-		{
-			get { return BackgroundImage; }
-		}
+		public Image? Icon => BackgroundImage;
 
 		public Image Icon32 => Icon.Resize(32);
 
-		public IEnumerable<string> IconPaths
-		{
-			get
-			{
-				return PortraitPaths;
-			}
-		}
+		public IEnumerable<string> IconPaths => PortraitPaths;
 
-		public long ID
-		{
-			get;
-			set;
-		}
+		public long ID { get; set; }
 
-		public IEnumerable<Ability> IntrinsicAbilities
-		{
-			get { return Abilities; }
-		}
+		public IEnumerable<Ability> IntrinsicAbilities => Abilities;
 
 		public bool IsDisposed { get; set; }
 
-		public bool IsMemory
-		{
-			get;
-			set;
-		}
+		public bool IsMemory { get; set; }
 
 		public ObjectLocation<StarSystem> Location
 		{
@@ -155,7 +130,7 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// The name of this star system.
 		/// </summary>
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
 		/// <summary>
 		/// If true, the background image for this system will be centered, not tiled, in combat.
@@ -165,10 +140,7 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// Star systems are not owned, per se.
 		/// </summary>
-		public Empire Owner
-		{
-			get { return null; }
-		}
+		public Empire? Owner => null;
 
 		public IEnumerable<IAbilityObject> Parents
 		{
@@ -178,16 +150,13 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public Image Portrait
-		{
-			get { return BackgroundImage; }
-		}
+		public Image? Portrait => BackgroundImage;
 
 		public IEnumerable<string> PortraitPaths
 		{
 			get
 			{
-				yield return Path.Combine("Systems", BackgroundImagePath);
+				yield return Path.Combine("Systems", BackgroundImagePath ?? string.Empty);
 			}
 		}
 
@@ -215,7 +184,7 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		public ICollection<ObjectLocation<ISpaceObject>> SpaceObjectLocations { get; private set; }
 
-		public IEnumerable<ISpaceObject> SpaceObjects { get { return FindSpaceObjects<ISpaceObject>(); } }
+		public IEnumerable<ISpaceObject> SpaceObjects => FindSpaceObjects<ISpaceObject>();
 
 		public double Timestamp { get; set; }
 
@@ -223,9 +192,9 @@ namespace FrEee.Game.Objects.Space
 		/// Abilities for random warp points that appear in this system.
 		/// </summary>
 		[DoNotSerialize]
-		public RandomAbilityTemplate WarpPointAbilities { get { return warpPointAbilities; } set { warpPointAbilities = value; } }
+		public RandomAbilityTemplate? WarpPointAbilities { get => warpPointAbilities; set => warpPointAbilities = value; }
 
-		private ModReference<RandomAbilityTemplate> warpPointAbilities { get; set; }
+		private ModReference<RandomAbilityTemplate?>? warpPointAbilities { get; set; }
 
 		public bool AreCoordsInBounds(int x, int y)
 		{
@@ -270,7 +239,7 @@ namespace FrEee.Game.Objects.Space
 		/// <param name="index"></param>
 		/// <param name="filter"></param>
 		/// <returns></returns>
-		public bool DoesSectorHaveAbility(Point coords, Empire emp, string name, int index = 1, Func<Ability, bool> filter = null)
+		public bool DoesSectorHaveAbility(Point coords, Empire emp, string name, int index = 1, Func<Ability, bool>? filter = null)
 		{
 			var sobjs = FindSpaceObjects<ISpaceObject>().Where(o => o.Owner == emp && o.FindCoordinates() == coords);
 			return sobjs.SelectMany(o => o.UnstackedAbilities(true)).Where(a => a.Rule.Matches(name) && (filter == null || filter(a))).Any();
@@ -294,7 +263,7 @@ namespace FrEee.Game.Objects.Space
 		/// <typeparam name="T">The type of space object.</typeparam>
 		/// <param name="criteria">The criteria.</param>
 		/// <returns>The matching space objects.</returns>
-		public IEnumerable<T> FindSpaceObjects<T>(Func<T, bool> criteria = null)
+		public IEnumerable<T> FindSpaceObjects<T>(Func<T, bool>? criteria = null)
 		{
 			return SpaceObjectLocations.Select(l => l.Item).OfType<T>().Where(l => criteria == null || criteria(l));
 		}
@@ -324,7 +293,7 @@ namespace FrEee.Game.Objects.Space
 		/// <param name="index"></param>
 		/// <param name="filter"></param>
 		/// <returns></returns>
-		public bool HasAbility(Empire emp, string name, int index = 1, Func<Ability, bool> filter = null)
+		public bool HasAbility(Empire emp, string name, int index = 1, Func<Ability, bool>? filter = null)
 		{
 			return FindSpaceObjects<ISpaceObject>(o => o.Owner == emp).SelectMany(o => o.UnstackedAbilities(true)).Where(a => a.Rule.Matches(name) && (filter == null || filter(a))).Any();
 		}
@@ -334,7 +303,7 @@ namespace FrEee.Game.Objects.Space
 			return CheckVisibility(emp) >= Visibility.Visible && Timestamp < Galaxy.Current.Timestamp - 1;
 		}
 
-		public Sector PickRandomSector(PRNG prng = null)
+		public Sector PickRandomSector(PRNG? prng = null)
 		{
 			return new Sector(this, new Point(RandomHelper.Range(-Radius, Radius, prng), RandomHelper.Range(-Radius, Radius, prng)));
 		}
@@ -388,10 +357,7 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name ?? string.Empty;
 
 		/// <summary>
 		/// Marks this system as explored by a particular empire and adds an appropriate log entry for the player.

--- a/FrEee/Game/Objects/Space/StellarObject.cs
+++ b/FrEee/Game/Objects/Space/StellarObject.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Space
 {
 	/// <summary>
@@ -28,39 +30,27 @@ namespace FrEee.Game.Objects.Space
 		[DoNotSerialize]
 		public IList<Ability> Abilities
 		{
-			get
-			{
-				return IntrinsicAbilities;
-			}
-			set
-			{
-				IntrinsicAbilities = value;
-			}
+			get => IntrinsicAbilities;
+			set => IntrinsicAbilities = value;
 		}
 
 		public abstract AbilityTargets AbilityTarget { get; }
 
-		public virtual bool CanBeInFleet
-		{
-			get { return false; }
-		}
+		public virtual bool CanBeInFleet => false;
 
 		public abstract bool CanBeObscured { get; }
 
 		/// <summary>
 		/// Stellar objects can't normally warp.
 		/// </summary>
-		public virtual bool CanWarp { get { return false; } }
+		public virtual bool CanWarp => false;
 
 		public virtual IEnumerable<IAbilityObject> Children
 		{
 			get { yield break; }
 		}
 
-		public virtual ConstructionQueue ConstructionQueue
-		{
-			get { return null; }
-		}
+		public virtual ConstructionQueue? ConstructionQueue => null;
 
 		public virtual SafeDictionary<string, object> Data
 		{
@@ -101,27 +91,15 @@ namespace FrEee.Game.Objects.Space
 		/// <summary>
 		/// A description of this stellar object.
 		/// </summary>
-		public string Description { get; set; }
+		public string? Description { get; set; }
 
-		public bool HasInfiniteSupplies
-		{
-			get { return this.HasAbility("Quantum Reactor"); }
-		}
+		public bool HasInfiniteSupplies => this.HasAbility("Quantum Reactor");
 
-		public virtual Image Icon
-		{
-			get { return Pictures.GetIcon(this); }
-		}
+		public virtual Image Icon => Pictures.GetIcon(this);
 
 		public Image Icon32 => Icon.Resize(32);
 
-		public IEnumerable<string> IconPaths
-		{
-			get
-			{
-				return PortraitPaths;
-			}
-		}
+		public IEnumerable<string> IconPaths => PortraitPaths;
 
 		public long ID { get; set; }
 
@@ -135,56 +113,36 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		public IList<Ability> IntrinsicAbilities { get; private set; }
 
-		IEnumerable<Ability> IAbilityObject.IntrinsicAbilities
-		{
-			get { return IntrinsicAbilities; }
-		}
+		IEnumerable<Ability> IAbilityObject.IntrinsicAbilities => IntrinsicAbilities;
 
 		public bool IsDisposed { get; set; }
 
 		/// <summary>
 		/// Stellar objects by default can't be idle, because they can't take orders or build stuff to begin with.
 		/// </summary>
-		public virtual bool IsIdle
-		{
-			get { return false; }
-		}
+		public virtual bool IsIdle => false;
 
-		public bool IsMemory
-		{
-			get;
-			set;
-		}
+		public bool IsMemory { get; set; }
 
 		/// <summary>
 		/// Used for naming.
 		/// </summary>
 		public bool IsUnique { get; set; }
 
-		public string ModID
-		{
-			get;
-			set;
-		}
+		public string? ModID { get; set; }
 
 		/// <summary>
 		/// The name of this stellar object.
 		/// </summary>
-		public string Name { get; set; }
+		public string? Name { get; set; }
 
-		Empire IOwnable.Owner
-		{
-			get
-			{
-				return null;
-			}
-		}
+		Empire? IOwnable.Owner => null;
 
 		public virtual IEnumerable<IAbilityObject> Parents
 		{
 			get
 			{
-				if (Sector != null)
+				if (!(Sector is null))
 					yield return Sector;
 			}
 		}
@@ -193,30 +151,27 @@ namespace FrEee.Game.Objects.Space
 		/// Name of the picture used to represent this stellar object, excluding the file extension.
 		/// PNG files will be searched first, then BMP.
 		/// </summary>
-		public string PictureName { get; set; }
+		public string? PictureName { get; set; }
 
 		[DoNotSerialize]
-		public Image Portrait
-		{
-			get { return Pictures.GetPortrait(this); }
-		}
+		public Image Portrait => Pictures.GetPortrait(this);
 
 		public IEnumerable<string> PortraitPaths
 		{
 			get
 			{
 				if (Mod.Current.RootPath != null)
-					yield return Path.Combine("Mods", Mod.Current.RootPath, "Pictures", "Planets", PictureName);
-				yield return Path.Combine("Pictures", "Planets", PictureName);
+					yield return Path.Combine("Mods", Mod.Current.RootPath, "Pictures", "Planets", PictureName ?? string.Empty);
+				yield return Path.Combine("Pictures", "Planets", PictureName ?? string.Empty);
 			}
 		}
 
 		[DoNotCopy(false)]
-		public virtual Sector Sector
+		public virtual Sector? Sector
 		{
 			get
 			{
-				if (sector == null)
+				if (sector is null)
 					sector = this.FindSector();
 				return sector;
 			}
@@ -224,7 +179,7 @@ namespace FrEee.Game.Objects.Space
 			{
 				var oldsector = sector;
 				sector = value;
-				if (value == null)
+				if (value is null)
 				{
 					if (oldsector != null)
 						oldsector.Remove(this);
@@ -237,38 +192,28 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public StarSystem StarSystem
-		{
-			get { return Sector?.StarSystem; }
-		}
+		public StarSystem? StarSystem => Sector?.StarSystem;
 
-		public StellarSize StellarSize
-		{
-			get;
-			set;
-		}
+		public StellarSize StellarSize { get; set; }
 
 		/// <summary>
 		/// Resources stored on this stellar object.
 		/// </summary>
 		public ResourceQuantity StoredResources { get; private set; }
 
-		public int SupplyStorage
-		{
-			get { return this.GetAbilityValue("Supply Storage").ToInt(); }
-		}
+		public int SupplyStorage => this.GetAbilityValue("Supply Storage").ToInt();
 
 		/// <summary>
 		/// Parameters from the mod meta templates.
 		/// </summary>
-		public IDictionary<string, object> TemplateParameters { get; set; }
+		public IDictionary<string, object>? TemplateParameters { get; set; }
 
 		public double Timestamp { get; set; }
-		private Sector sector;
+		private Sector? sector;
 
 		public Visibility CheckVisibility(Empire emp)
 		{
-			if ((Sector == null || StarSystem == null) && Mod.Current.StellarObjectTemplates.Contains(this))
+			if ((Sector is null || StarSystem == null) && Mod.Current.StellarObjectTemplates.Contains(this))
 				return Visibility.Scanned; // can always see the mod
 
 			return this.CheckSpaceObjectVisibility(emp);
@@ -291,10 +236,7 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		/// <param name="emp"></param>
 		/// <returns></returns>
-		public virtual bool IsHostileTo(Empire emp)
-		{
-			return false;
-		}
+		public virtual bool IsHostileTo(Empire emp) => false;
 
 		public bool IsObsoleteMemory(Empire emp)
 		{
@@ -315,9 +257,6 @@ namespace FrEee.Game.Objects.Space
 				Dispose();
 		}
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name ?? string.Empty;
 	}
 }

--- a/FrEee/Game/Objects/Space/Storm.cs
+++ b/FrEee/Game/Objects/Space/Storm.cs
@@ -5,6 +5,8 @@ using FrEee.Utility;
 using FrEee.Utility.Extensions;
 using System;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Space
 {
 	/// <summary>
@@ -13,17 +15,14 @@ namespace FrEee.Game.Objects.Space
 	[Serializable]
 	public class Storm : StellarObject, ITemplate<Storm>, IDataObject
 	{
-		public override AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.Storm; }
-		}
+		public override AbilityTargets AbilityTarget => AbilityTargets.Storm;
 
 		public override bool CanBeObscured => false;
 
 		/// <summary>
 		/// Some sort of combat image? Where are these stored anyway?
 		/// </summary>
-		public string CombatTile { get; set; }
+		public string? CombatTile { get; set; }
 
 		public override SafeDictionary<string, object> Data
 		{
@@ -40,13 +39,7 @@ namespace FrEee.Game.Objects.Space
 			}
 		}
 
-		public Empire Owner
-		{
-			get
-			{
-				return null;
-			}
-		}
+		public Empire? Owner => null;
 
 		/// <summary>
 		/// Just copy the storm's data.

--- a/FrEee/Game/Objects/Space/WarpPoint.cs
+++ b/FrEee/Game/Objects/Space/WarpPoint.cs
@@ -6,6 +6,8 @@ using FrEee.Utility.Extensions;
 using System;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Game.Objects.Space
 {
 	/// <summary>
@@ -14,10 +16,7 @@ namespace FrEee.Game.Objects.Space
 	[Serializable]
 	public class WarpPoint : StellarObject, ITemplate<WarpPoint>, IReferrable, IDataObject
 	{
-		public override AbilityTargets AbilityTarget
-		{
-			get { return AbilityTargets.WarpPoint; }
-		}
+		public override AbilityTargets AbilityTarget => AbilityTargets.WarpPoint;
 
 		public override bool CanBeObscured => false;
 
@@ -49,28 +48,22 @@ namespace FrEee.Game.Objects.Space
 		/// </summary>
 		public bool IsUnusual { get; set; }
 
-		public Empire Owner
-		{
-			get
-			{
-				return null;
-			}
-		}
+		public Empire? Owner => null;
 
 		/// <summary>
 		/// The sector that ships will appear in when they go through this warp point.
 		/// If null, the warp point is still unexplored by the current empire.
 		/// </summary>
-		public Sector Target { get; set; }
+		public Sector? Target { get; set; }
 
 		/// <summary>
 		/// The star system that ships will appear in when they go through this warp point.
 		/// </summary>
-		public ObjectLocation<StarSystem> TargetStarSystemLocation
+		public ObjectLocation<StarSystem>? TargetStarSystemLocation
 		{
 			get
 			{
-				if (Target == null)
+				if (Target is null)
 					return null;
 				return Galaxy.Current.StarSystemLocations.SingleOrDefault(ssl => ssl.Item == Target.StarSystem);
 			}
@@ -80,8 +73,8 @@ namespace FrEee.Game.Objects.Space
 		{
 			if (closeBothWays)
 			{
-				var wps = Target.SpaceObjects.OfType<WarpPoint>().Where(q => q.Target == Sector);
-				foreach (var wp in wps)
+				var wps = Target?.SpaceObjects.OfType<WarpPoint>().Where(q => q.Target == Sector);
+				foreach (var wp in wps ?? Enumerable.Empty<WarpPoint>())
 					wp.Dispose();
 			}
 			Dispose();

--- a/FrEee/Modding/Formula.cs
+++ b/FrEee/Modding/Formula.cs
@@ -196,7 +196,7 @@ namespace FrEee.Modding
 			return Evaluate(host, variables);
 		}
 
-		public abstract T Evaluate(object host, IDictionary<string, object>? variables = null);
+		public abstract T Evaluate(object host, IDictionary<string, object> variables = null);
 
 		public override string ToString()
 		{
@@ -212,7 +212,7 @@ namespace FrEee.Modding
 			}
 		}
 
-		public abstract Formula<string> ToStringFormula(CultureInfo? c = null);
+		public abstract Formula<string> ToStringFormula(CultureInfo c = null);
 
 		protected abstract T ComputeValue();
 	}

--- a/FrEee/Modding/Formula.cs
+++ b/FrEee/Modding/Formula.cs
@@ -196,7 +196,7 @@ namespace FrEee.Modding
 			return Evaluate(host, variables);
 		}
 
-		public abstract T Evaluate(object host, IDictionary<string, object> variables = null);
+		public abstract T Evaluate(object host, IDictionary<string, object>? variables = null);
 
 		public override string ToString()
 		{
@@ -212,7 +212,7 @@ namespace FrEee.Modding
 			}
 		}
 
-		public abstract Formula<string> ToStringFormula(CultureInfo c = null);
+		public abstract Formula<string> ToStringFormula(CultureInfo? c = null);
 
 		protected abstract T ComputeValue();
 	}

--- a/FrEee/Utility/ClientSafeAttribute.cs
+++ b/FrEee/Utility/ClientSafeAttribute.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+
+#nullable enable
 
 namespace FrEee.Utility
 {

--- a/FrEee/Utility/ClientSideCache.cs
+++ b/FrEee/Utility/ClientSideCache.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Game.Objects.Civilization;
+using FrEee.Game.Objects.Civilization;
 using System;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -10,28 +12,19 @@ namespace FrEee.Utility
 	/// <typeparam name="T"></typeparam>
 	public class ClientSideCache<T>
 	{
-		public ClientSideCache(Func<T> compute)
+		public ClientSideCache(Func<T?> compute)
 		{
 			this.compute = compute;
 			IsDirty = true;
 		}
 
-		public bool IsCacheEnabled
-		{
-			get
-			{
-				return IsServerSideCacheEnabled || Empire.Current != null;
-			}
-		}
+		public bool IsCacheEnabled => IsServerSideCacheEnabled || Empire.Current != null;
 
 		public bool IsDirty { get; private set; }
 
 		public bool IsServerSideCacheEnabled
 		{
-			get
-			{
-				return isServerSideCacheEnabled;
-			}
+			get => isServerSideCacheEnabled;
 			set
 			{
 				isServerSideCacheEnabled = value;
@@ -40,35 +33,32 @@ namespace FrEee.Utility
 			}
 		}
 
-		public T Value
+		public T? Value
 		{
 			get
 			{
 				if (IsCacheEnabled)
 				{
-					if (!IsDirty)
-						return value;
-					else
+					if (IsDirty || value is null)
 					{
 						value = compute();
 						IsDirty = false;
 						return value;
 					}
+					else
+						return value;
 				}
 				else
 					return compute();
 			}
 		}
 
-		private Func<T> compute;
+		private Func<T?> compute;
 
 		private bool isServerSideCacheEnabled;
 
-		private T value;
+		private T? value;
 
-		public static implicit operator T(ClientSideCache<T> cache)
-		{
-			return cache.Value;
-		}
+		public static implicit operator T?(ClientSideCache<T> cache) => cache.Value;
 	}
 }

--- a/FrEee/Utility/ClientUtilities.cs
+++ b/FrEee/Utility/ClientUtilities.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
+
+#nullable enable
 
 namespace FrEee.Utility
 {

--- a/FrEee/Utility/ConnectivityGraph.cs
+++ b/FrEee/Utility/ConnectivityGraph.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -30,31 +32,16 @@ namespace FrEee.Utility
 		/// <summary>
 		/// Any connections that have been made.
 		/// </summary>
-		public SafeDictionary<T, HashSet<T>> Connections
-		{
-			get { return connections; }
-		}
+		public SafeDictionary<T, HashSet<T>> Connections => connections;
 
-		public int Count
-		{
-			get { return items.Count; }
-		}
+		public int Count => items.Count;
 
 		/// <summary>
 		/// Is the graph connected? That is, are any two nodes connected? Or, is there no more than one subgraph?
 		/// </summary>
-		public bool IsConnected
-		{
-			get
-			{
-				return Subgraphs.Count() <= 1;
-			}
-		}
+		public bool IsConnected => Subgraphs.Count() <= 1;
 
-		public bool IsReadOnly
-		{
-			get { return items.IsReadOnly; }
-		}
+		public bool IsReadOnly => items.IsReadOnly;
 
 		/// <summary>
 		/// Any discrete connected subgraphs of this graph.
@@ -158,7 +145,7 @@ namespace FrEee.Utility
 		/// <param name="t2"></param>
 		/// <param name="traversed"></param>
 		/// <returns>The distance, or null if either the destination cannot be reached or the start node has already been traversed..</returns>
-		public int? ComputeDistance(T start, T end, ICollection<T> traversed = null)
+		public int? ComputeDistance(T start, T end, ICollection<T>? traversed = null)
 		{
 			if (traversed == null)
 				traversed = new HashSet<T>();
@@ -168,7 +155,7 @@ namespace FrEee.Utility
 
 			traversed.Add(start);
 
-			if ((object)start == (object)end)
+			if ((object?)start == (object?)end)
 				return 0; // we're already there!
 
 			var exits = GetExits(start);
@@ -330,7 +317,7 @@ namespace FrEee.Utility
 			var result = items.Remove(item);
 			foreach (var kvp in connections.ToArray())
 			{
-				if ((object)kvp.Key == (object)item)
+				if ((object?)kvp.Key == (object?)item)
 					connections.Remove(item);
 				else if (kvp.Value.Contains(item))
 					kvp.Value.Remove(item);

--- a/FrEee/Utility/DataReference.cs
+++ b/FrEee/Utility/DataReference.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Utility.Extensions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -30,10 +32,7 @@ namespace FrEee.Utility
 		[field: NonSerialized]
 		public ObjectGraphContext Context { get; set; }
 
-		public string Data
-		{
-			get; set;
-		}
+		public string? Data { get; set; }
 
 		public bool HasValue
 		{
@@ -47,14 +46,8 @@ namespace FrEee.Utility
 		[JsonIgnore]
 		public int ID
 		{
-			get
-			{
-				return int.Parse(Data);
-			}
-			set
-			{
-				Data = value.ToString();
-			}
+			get => int.Parse(Data);
+			set => Data = value.ToString();
 		}
 
 		[JsonIgnore]
@@ -83,20 +76,11 @@ namespace FrEee.Utility
 			}
 		}
 
-		object IData.Value
-		{
-			get
-			{
-				return Value;
-			}
-		}
+		object? IData.Value => Value;
 
-		public static implicit operator T(DataReference<T> reference)
-		{
-			return reference.Value;
-		}
+		public static implicit operator T(DataReference<T> reference) => reference.Value;
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			// nothing to do here, this is just used for serialization and such
 		}

--- a/FrEee/Utility/DataScalar.cs
+++ b/FrEee/Utility/DataScalar.cs
@@ -1,13 +1,15 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using Newtonsoft.Json;
 using System;
 using System.Globalization;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
 	public static class DataScalar
 	{
-		public static IDataScalar Create<T>(T o)
+		public static IDataScalar? Create<T>(T o)
 		{
 			if (o == null)
 				return null;
@@ -24,17 +26,11 @@ namespace FrEee.Utility
 	[Serializable]
 	public class DataScalar<T> : IDataScalar
 	{
-		public DataScalar(T value = default(T))
-		{
-			Value = value;
-		}
+		public DataScalar(T value = default) => Value = value;
 
 		public string Data
 		{
-			get
-			{
-				return Type.Name + ":" + Convert.ToString(Value, CultureInfo.InvariantCulture);
-			}
+			get => Type.Name + ":" + Convert.ToString(Value, CultureInfo.InvariantCulture);
 			set
 			{
 				var data = value.Substring(value.IndexOf(":") + 1);
@@ -48,15 +44,9 @@ namespace FrEee.Utility
 		[JsonIgnore]
 		public T Value { get; set; }
 
-		object IData.Value { get { return Value; } }
+		object? IData.Value => Value;
 
-		private SafeType Type
-		{
-			get
-			{
-				return new SafeType(typeof(T));
-			}
-		}
+		private SafeType Type => new SafeType(typeof(T));
 	}
 
 	public interface IDataScalar : IData

--- a/FrEee/Utility/DynamicDictionary.cs
+++ b/FrEee/Utility/DynamicDictionary.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -15,30 +17,15 @@ namespace FrEee.Utility
 			dict = new SafeDictionary<object, object>();
 		}
 
-		public int Count
-		{
-			get { return dict.Count; }
-		}
+		public int Count => dict.Count;
 
-		public bool IsEmpty
-		{
-			get { return dict.Count == 0; }
-		}
+		public bool IsEmpty => dict.Count == 0;
 
-		public bool IsReadOnly
-		{
-			get { return dict.IsReadOnly; }
-		}
+		public bool IsReadOnly => dict.IsReadOnly;
 
-		public ICollection<object> Keys
-		{
-			get { return dict.Keys; }
-		}
+		public ICollection<object> Keys => dict.Keys;
 
-		public ICollection<object> Values
-		{
-			get { return dict.Values; }
-		}
+		public ICollection<object> Values => dict.Values;
 
 		private SafeDictionary<object, object> dict { get; set; }
 
@@ -50,71 +37,32 @@ namespace FrEee.Utility
 					dict[key] = new DynamicDictionary();
 				return dict[key];
 			}
-			set
-			{
-				dict[key] = value;
-			}
+			set => dict[key] = value;
 		}
 
-		public void Add(object key, object value)
-		{
-			dict.Add(key, value);
-		}
+		public void Add(object key, object value) => dict.Add(key, value);
 
-		public void Add(KeyValuePair<object, object> item)
-		{
-			dict.Add(item);
-		}
+		public void Add(KeyValuePair<object, object> item) => dict.Add(item);
 
-		public void Clear()
-		{
-			dict.Clear();
-		}
+		public void Clear() => dict.Clear();
 
-		public bool Contains(KeyValuePair<object, object> item)
-		{
-			return dict.Contains(item);
-		}
+		public bool Contains(KeyValuePair<object, object> item) => dict.Contains(item);
 
-		public bool ContainsKey(object key)
-		{
-			return dict.ContainsKey(key);
-		}
+		public bool ContainsKey(object key) => dict.ContainsKey(key);
 
-		public void CopyTo(KeyValuePair<object, object>[] array, int arrayIndex)
-		{
-			dict.CopyTo(array, arrayIndex);
-		}
+		public void CopyTo(KeyValuePair<object, object>[] array, int arrayIndex) => dict.CopyTo(array, arrayIndex);
 
-		public override IEnumerable<string> GetDynamicMemberNames()
-		{
-			return dict.Keys.OfType<string>();
-		}
+		public override IEnumerable<string> GetDynamicMemberNames() => dict.Keys.OfType<string>();
 
-		public IEnumerator<KeyValuePair<object, object>> GetEnumerator()
-		{
-			return dict.GetEnumerator();
-		}
+		public IEnumerator<KeyValuePair<object, object>> GetEnumerator() => dict.GetEnumerator();
 
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-		{
-			return GetEnumerator();
-		}
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
 
-		public bool HasProperty(string prop)
-		{
-			return dict.ContainsKey(prop);
-		}
+		public bool HasProperty(string prop) => dict.ContainsKey(prop);
 
-		public bool Remove(object key)
-		{
-			return dict.Remove(key);
-		}
+		public bool Remove(object key) => dict.Remove(key);
 
-		public bool Remove(KeyValuePair<object, object> item)
-		{
-			return dict.Remove(item);
-		}
+		public bool Remove(KeyValuePair<object, object> item) => dict.Remove(item);
 
 		public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
 		{

--- a/FrEee/Utility/Extensions/AbilityExtensions.cs
+++ b/FrEee/Utility/Extensions/AbilityExtensions.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Abilities;
@@ -7,11 +11,8 @@ using FrEee.Game.Objects.Space;
 using FrEee.Game.Objects.Technology;
 using FrEee.Game.Objects.Vehicles;
 using FrEee.Modding;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {
@@ -25,7 +26,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="obj"></param>
 		/// <returns></returns>
-		public static IEnumerable<Ability> Abilities(this IAbilityObject obj, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<Ability>? Abilities(this IAbilityObject obj, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			if (obj == null)
 				return Enumerable.Empty<Ability>();
@@ -41,7 +42,7 @@ namespace FrEee.Utility.Extensions
 			return obj.UnstackedAbilities(true, sourceFilter).Stack(obj);
 		}
 
-		public static ILookup<Ability, Ability> AbilityTree(this IAbilityObject obj, Func<IAbilityObject, bool> sourceFilter = null)
+		public static ILookup<Ability, Ability> AbilityTree(this IAbilityObject obj, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			return obj.UnstackedAbilities(true, sourceFilter).StackToTree(obj);
 		}
@@ -130,7 +131,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="obj"></param>
 		/// <param name="includeShared"></param>
 		/// <returns></returns>
-		public static IEnumerable<Ability> AncestorAbilities(this IAbilityObject obj, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<Ability> AncestorAbilities(this IAbilityObject obj, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			var abils = new List<Ability>();
 			foreach (var p in obj.Ancestors(sourceFilter).ExceptSingle(null))
@@ -138,7 +139,7 @@ namespace FrEee.Utility.Extensions
 			return abils.Where(a => a.Rule == null || a.Rule.CanTarget(obj.AbilityTarget));
 		}
 
-		public static IEnumerable<IAbilityObject> Ancestors(this IAbilityObject obj, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<IAbilityObject> Ancestors(this IAbilityObject obj, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			if (obj == null)
 				yield break;
@@ -178,7 +179,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="obj"></param>
 		/// <param name="includeShared"></param>
 		/// <returns></returns>
-		public static IEnumerable<Ability> DescendantAbilities(this IAbilityObject obj, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<Ability> DescendantAbilities(this IAbilityObject obj, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			var abils = new List<Ability>();
 			foreach (var c in obj.Descendants(sourceFilter))
@@ -186,7 +187,7 @@ namespace FrEee.Utility.Extensions
 			return abils.Where(a => a.Rule == null || a.Rule.CanTarget(obj.AbilityTarget));
 		}
 
-		public static IEnumerable<IAbilityObject> Descendants(this IAbilityObject obj, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<IAbilityObject> Descendants(this IAbilityObject obj, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			var result = new HashSet<IAbilityObject>();
 			if (obj != null)
@@ -204,7 +205,7 @@ namespace FrEee.Utility.Extensions
 			return result;
 		}
 
-		public static IEnumerable<Ability> EmpireAbilities(this ICommonAbilityObject obj, Empire emp, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<Ability>? EmpireAbilities(this ICommonAbilityObject obj, Empire emp, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			if (obj == null)
 				return Enumerable.Empty<Ability>();
@@ -234,7 +235,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="obj"></param>
 		/// <param name="sourceFilter"></param>
 		/// <returns></returns>
-		public static IEnumerable<Ability> EmpireCommonAbilities(this IAbilityObject obj, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<Ability> EmpireCommonAbilities(this IAbilityObject obj, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			// Unowned objects cannot empire common abilities.
 			var ownable = obj as IOwnableAbilityObject;
@@ -308,7 +309,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="index"></param>
 		/// <param name="filter"></param>
 		/// <returns></returns>
-		public static string GetEmpireAbilityValue(this ICommonAbilityObject obj, Empire emp, string name, int index = 1, Func<Ability, bool> filter = null)
+		public static string? GetEmpireAbilityValue(this ICommonAbilityObject obj, Empire emp, string name, int index = 1, Func<Ability, bool>? filter = null)
 		{
 			if (obj == null)
 				return null;
@@ -326,14 +327,14 @@ namespace FrEee.Utility.Extensions
 				}
 			}
 
-			IEnumerable<Ability> abils;
+			IEnumerable<Ability>? abils;
 			var subabils = obj.GetContainedAbilityObjects(emp).SelectMany(o => o.UnstackedAbilities(true).Where(a => a.Rule.Name == name));
 			if (obj is IAbilityObject)
-				abils = ((IAbilityObject)obj).Abilities().Where(a => a.Rule != null && a.Rule.Name == name).Concat(subabils).Stack(obj);
+				abils = ((IAbilityObject)obj).Abilities()?.Where(a => a.Rule != null && a.Rule.Name == name).Concat(subabils).Stack(obj);
 			else
 				abils = subabils;
-			abils = abils.Where(a => a.Rule != null && a.Rule.Matches(name) && a.Rule.CanTarget(obj.AbilityTarget) && (filter == null || filter(a)));
-			string result;
+			abils = abils?.Where(a => a.Rule != null && a.Rule.Matches(name) && a.Rule.CanTarget(obj.AbilityTarget) && (filter == null || filter(a)));
+			string? result;
 			if (!abils.Any())
 				result = null;
 			else
@@ -356,25 +357,25 @@ namespace FrEee.Utility.Extensions
 		/// <param name="index">The ability value index (usually 1 or 2).</param>
 		/// <param name="filter">A filter for the abilities. For instance, you might want to filter by the ability grouping rule's value.</param>
 		/// <returns>The ability value.</returns>
-		public static string GetAbilityValue(this IAbilityObject obj, string name, int index = 1, bool includeShared = true, bool includeEmpireCommon = true, Func<Ability, bool> filter = null)
+		public static string? GetAbilityValue(this IAbilityObject obj, string name, int index = 1, bool includeShared = true, bool includeEmpireCommon = true, Func<Ability, bool>? filter = null)
 		{
 			if (obj == null)
 				return null;
 
 			var abils = obj.Abilities();
 			if (includeShared)
-				abils = abils.Union(obj.SharedAbilities());
+				abils = abils?.Union(obj.SharedAbilities());
 			if (includeEmpireCommon)
-				abils = abils.Union(obj.EmpireCommonAbilities());
+				abils = abils?.Union(obj.EmpireCommonAbilities());
 
-			abils = abils.Where(a => a.Rule != null && a.Rule.Matches(name) && a.Rule.CanTarget(obj.AbilityTarget) && (filter == null || filter(a)));
+			abils = abils?.Where(a => a.Rule != null && a.Rule.Matches(name) && a.Rule.CanTarget(obj.AbilityTarget) && (filter == null || filter(a)));
 			abils = abils.Stack(obj);
 			if (!abils.Any())
 				return null;
 			return abils.First().Values[index - 1];
 		}
 
-		public static string GetAbilityValue(this IEnumerable<IAbilityObject> objs, string name, IAbilityObject stackTo, int index = 1, bool includeShared = true, bool includeEmpireCommon = true, Func<Ability, bool> filter = null)
+		public static string? GetAbilityValue(this IEnumerable<IAbilityObject> objs, string name, IAbilityObject stackTo, int index = 1, bool includeShared = true, bool includeEmpireCommon = true, Func<Ability, bool>? filter = null)
 		{
 			var tuples = objs.Squash(o => o.Abilities());
 			if (includeShared)
@@ -392,7 +393,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="obj"></param>
 		/// <returns></returns>
-		public static IEnumerable<Ability> SharedAbilities(this IAbilityObject obj, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<Ability> SharedAbilities(this IAbilityObject obj, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			// Unowned objects cannot have abilities shared to them.
 			var ownable = obj as IOwnableAbilityObject;
@@ -420,7 +421,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="obj"></param>
 		/// <returns></returns>
-		public static IEnumerable<Ability> SharedAbilities(this ICommonAbilityObject obj, Empire empire, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<Ability> SharedAbilities(this ICommonAbilityObject obj, Empire empire, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			if (obj == null)
 				yield break;
@@ -477,7 +478,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="obj"></param>
 		/// <param name="includeShared"></param>
 		/// <returns></returns>
-		public static IEnumerable<Ability> UnstackedAbilities(this IAbilityObject obj, bool includeShared, Func<IAbilityObject, bool> sourceFilter = null)
+		public static IEnumerable<Ability> UnstackedAbilities(this IAbilityObject obj, bool includeShared, Func<IAbilityObject, bool>? sourceFilter = null)
 		{
 			if (obj == null)
 				return Enumerable.Empty<Ability>();

--- a/FrEee/Utility/Extensions/AbilityExtensions.cs
+++ b/FrEee/Utility/Extensions/AbilityExtensions.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Abilities;
 using FrEee.Game.Objects.Civilization;

--- a/FrEee/Utility/Extensions/ChecksExtensions.cs
+++ b/FrEee/Utility/Extensions/ChecksExtensions.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Enumerations;
+using FrEee.Game.Enumerations;
 using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Abilities;
 using FrEee.Game.Objects.Civilization;
@@ -12,6 +12,8 @@ using System.Drawing;
 using System.Dynamic;
 using System.Linq;
 using System.Reflection;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {
@@ -33,7 +35,7 @@ namespace FrEee.Utility.Extensions
 		{
 			if (attributeCache[mi] == null)
 				attributeCache[mi] = Attribute.GetCustomAttributes(mi).ToArray();
-			var atts = attributeCache[mi].OfType<T>();
+			var atts = attributeCache[mi]?.OfType<T>();
 			foreach (var att in atts)
 				yield return att;
 			if (interfaceCache[mi.DeclaringType] == null)
@@ -42,7 +44,7 @@ namespace FrEee.Utility.Extensions
 			{
 				if (memberCache[i] == null)
 					memberCache[i] = i.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).ToArray(); // TODO - refactor into method
-				var mi2 = memberCache[i].SingleOrDefault(x => x.MemberType == mi.MemberType && x.Name == mi.Name);
+				var mi2 = memberCache[i]?.SingleOrDefault(x => x.MemberType == mi.MemberType && x.Name == mi.Name);
 				if (mi2 != null)
 				{
 					foreach (var att2 in mi2.GetAttributes<T>())
@@ -75,9 +77,9 @@ namespace FrEee.Utility.Extensions
 		/// <returns></returns>
 		public static bool HasAbility(this ICommonAbilityObject obj, string abilityName, Empire emp, bool includeShared = true)
 		{
-			IEnumerable<Ability> abils;
+			IEnumerable<Ability>? abils;
 			if (includeShared)
-				abils = obj.EmpireAbilities(emp).Union(obj.SharedAbilities(emp));
+				abils = obj.EmpireAbilities(emp)?.Union(obj.SharedAbilities(emp));
 			else
 				abils = obj.EmpireAbilities(emp);
 			return abils.Any(abil => abil.Rule != null && abil.Rule.Matches(abilityName));
@@ -196,8 +198,8 @@ namespace FrEee.Utility.Extensions
 		{
 			var sys = sobj.StarSystem;
 			var sec = sobj.Sector;
-			var sensors = sys.EmpireAbilities(emp).Where(a => a.Rule.Name == "Sensor Level");
-			var cloaks = sobj.Abilities().Where(a => a.Rule.Name == "Cloak Level");
+			var sensors = sys.EmpireAbilities(emp)?.Where(a => a.Rule.Name == "Sensor Level");
+			var cloaks = sobj.Abilities()?.Where(a => a.Rule.Name == "Cloak Level");
 			var joined = from sensor in sensors
 						 join cloak in cloaks on sensor.Value1.Value equals cloak.Value1.Value into gj
 						 from subcloak in gj.DefaultIfEmpty()

--- a/FrEee/Utility/Extensions/CommonExtensions.cs
+++ b/FrEee/Utility/Extensions/CommonExtensions.cs
@@ -291,13 +291,13 @@ namespace FrEee.Utility.Extensions
 		/// <typeparam name="T"></typeparam>
 		/// <param name="list"></param>
 		/// <param name="condition"></param>
-		public static void DisposeAll<T>(this IEnumerable<T> list, Func<T, bool>? condition = null) where T : IDisposable
+		public static void DisposeAll<T>(this IEnumerable<T> list, Func<T, bool> condition = null) where T : IDisposable
 		{
 			foreach (var d in list.Where(d => condition == null || condition(d)).ToArray())
 				d.Dispose();
 		}
 
-		public static void DisposeAndLog(this IFoggable obj, string? message = null, params Empire[] empiresToSkipMessage)
+		public static void DisposeAndLog(this IFoggable obj, string message = null, params Empire[] empiresToSkipMessage)
 		{
 			if (Empire.Current == null)
 			{
@@ -393,7 +393,7 @@ namespace FrEee.Utility.Extensions
 		/// Finds the cargo container which contains this unit.
 		/// </summary>
 		/// <returns></returns>
-		public static ICargoContainer? FindContainer(this IUnit unit)
+		public static ICargoContainer FindContainer(this IUnit unit)
 		{
 			var containers = Galaxy.Current.FindSpaceObjects<ICargoContainer>().Where(cc => !(cc is Fleet) && cc.Cargo != null && cc.Cargo.Units.Contains(unit));
 			if (!containers.Any())
@@ -456,7 +456,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="t"></param>
 		/// <param name="propName"></param>
 		/// <returns></returns>
-		public static PropertyInfo? FindProperty(this Type type, string propName)
+		public static PropertyInfo FindProperty(this Type type, string propName)
 		{
 			var p = type.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 			if (p != null)
@@ -482,7 +482,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="sobj"></param>
 		/// <returns></returns>
-		public static Sector? FindSector(this ISpaceObject sobj)
+		public static Sector FindSector(this ISpaceObject sobj)
 		{
 			var sys = sobj.FindStarSystem();
 			if (sys == null)
@@ -496,7 +496,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="sobj"></param>
 		/// <returns></returns>
-		public static StarSystem? FindStarSystem(this ISpaceObject sobj)
+		public static StarSystem FindStarSystem(this ISpaceObject sobj)
 		{
 			var loc = Galaxy.Current.StarSystemLocations.SingleOrDefault(l => l.Item.Contains(sobj));
 			/*if (loc == null)
@@ -632,7 +632,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="o"></param>
 		/// <param name="propertyName"></param>
 		/// <returns></returns>
-		public static object? GetPropertyValue(this object o, string propertyName)
+		public static object GetPropertyValue(this object o, string propertyName)
 		{
 			if (o == null)
 				return null;
@@ -672,7 +672,7 @@ namespace FrEee.Utility.Extensions
 		/// <returns></returns>
 		public static ResourceQuantity GrossIncome(this IIncomeProducer o) => o.StandardIncome() + o.RemoteMiningIncome() + o.RawResourceIncome();
 
-		public static object? Instantiate(this Type type, params object[] args)
+		public static object Instantiate(this Type type, params object[] args)
 		{
 			if (type.Name == "Battle")
 				return typeof(SpaceBattle).Instantiate(); // HACK - old savegame compatibility

--- a/FrEee/Utility/Extensions/CommonExtensions.cs
+++ b/FrEee/Utility/Extensions/CommonExtensions.cs
@@ -291,13 +291,13 @@ namespace FrEee.Utility.Extensions
 		/// <typeparam name="T"></typeparam>
 		/// <param name="list"></param>
 		/// <param name="condition"></param>
-		public static void DisposeAll<T>(this IEnumerable<T> list, Func<T, bool> condition = null) where T : IDisposable
+		public static void DisposeAll<T>(this IEnumerable<T> list, Func<T, bool>? condition = null) where T : IDisposable
 		{
 			foreach (var d in list.Where(d => condition == null || condition(d)).ToArray())
 				d.Dispose();
 		}
 
-		public static void DisposeAndLog(this IFoggable obj, string message = null, params Empire[] empiresToSkipMessage)
+		public static void DisposeAndLog(this IFoggable obj, string? message = null, params Empire[] empiresToSkipMessage)
 		{
 			if (Empire.Current == null)
 			{
@@ -393,7 +393,7 @@ namespace FrEee.Utility.Extensions
 		/// Finds the cargo container which contains this unit.
 		/// </summary>
 		/// <returns></returns>
-		public static ICargoContainer FindContainer(this IUnit unit)
+		public static ICargoContainer? FindContainer(this IUnit unit)
 		{
 			var containers = Galaxy.Current.FindSpaceObjects<ICargoContainer>().Where(cc => !(cc is Fleet) && cc.Cargo != null && cc.Cargo.Units.Contains(unit));
 			if (!containers.Any())
@@ -424,7 +424,7 @@ namespace FrEee.Utility.Extensions
 		public static T FindMemory<T>(this T f, Empire emp) where T : IFoggable, IReferrable
 		{
 			if (f == null)
-				return default(T);
+				return default;
 			if (emp == null)
 				return f; // host can see everything
 			return (T)emp.Memory[f.ID];
@@ -456,23 +456,23 @@ namespace FrEee.Utility.Extensions
 		/// <param name="t"></param>
 		/// <param name="propName"></param>
 		/// <returns></returns>
-		public static PropertyInfo FindProperty(this Type type, string propName)
+		public static PropertyInfo? FindProperty(this Type type, string propName)
 		{
 			var p = type.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 			if (p != null)
-				return p.DeclaringType.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+				return p.DeclaringType?.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 			var b = type.BaseType;
 			if (b != null)
 			{
 				var bp = b.FindProperty(propName);
 				if (bp != null)
-					return bp.DeclaringType.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+					return bp.DeclaringType?.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 			}
 			foreach (var i in type.GetInterfaces())
 			{
 				var ip = i.FindProperty(propName);
 				if (ip != null)
-					return ip.DeclaringType.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+					return ip.DeclaringType?.GetProperty(propName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 			}
 			return null;
 		}
@@ -482,7 +482,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="sobj"></param>
 		/// <returns></returns>
-		public static Sector FindSector(this ISpaceObject sobj)
+		public static Sector? FindSector(this ISpaceObject sobj)
 		{
 			var sys = sobj.FindStarSystem();
 			if (sys == null)
@@ -496,7 +496,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="sobj"></param>
 		/// <returns></returns>
-		public static StarSystem FindStarSystem(this ISpaceObject sobj)
+		public static StarSystem? FindStarSystem(this ISpaceObject sobj)
 		{
 			var loc = Galaxy.Current.StarSystemLocations.SingleOrDefault(l => l.Item.Contains(sobj));
 			/*if (loc == null)
@@ -632,7 +632,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="o"></param>
 		/// <param name="propertyName"></param>
 		/// <returns></returns>
-		public static object GetPropertyValue(this object o, string propertyName)
+		public static object? GetPropertyValue(this object o, string propertyName)
 		{
 			if (o == null)
 				return null;
@@ -651,50 +651,28 @@ namespace FrEee.Utility.Extensions
 			return o == null ? 0 : o.GetHashCode();
 		}
 
-		public static Type GetVehicleType(this VehicleTypes vt)
-		{
-			switch (vt)
+		public static Type GetVehicleType(this VehicleTypes vt) =>
+			vt switch
 			{
-				case VehicleTypes.Ship:
-					return typeof(Ship);
-
-				case VehicleTypes.Base:
-					return typeof(Base);
-
-				case VehicleTypes.Fighter:
-					return typeof(Fighter);
-
-				case VehicleTypes.Troop:
-					return typeof(Troop);
-
-				case VehicleTypes.Mine:
-					return typeof(Mine);
-
-				case VehicleTypes.Satellite:
-					return typeof(Satellite);
-
-				case VehicleTypes.Drone:
-					return typeof(Drone);
-
-				case VehicleTypes.WeaponPlatform:
-					return typeof(WeaponPlatform);
-
-				default:
-					throw new Exception("No type is available for vehicle type " + vt);
-			}
-		}
+				VehicleTypes.Ship => typeof(Ship),
+				VehicleTypes.Base => typeof(Base),
+				VehicleTypes.Fighter => typeof(Fighter),
+				VehicleTypes.Troop => typeof(Troop),
+				VehicleTypes.Mine => typeof(Mine),
+				VehicleTypes.Satellite => typeof(Satellite),
+				VehicleTypes.Drone => typeof(Drone),
+				VehicleTypes.WeaponPlatform => typeof(WeaponPlatform),
+				_ => throw new Exception("No type is available for vehicle type " + vt)
+			};
 
 		/// <summary>
 		/// All income provided by an object.
 		/// </summary>
 		/// <param name="o"></param>
 		/// <returns></returns>
-		public static ResourceQuantity GrossIncome(this IIncomeProducer o)
-		{
-			return o.StandardIncome() + o.RemoteMiningIncome() + o.RawResourceIncome();
-		}
+		public static ResourceQuantity GrossIncome(this IIncomeProducer o) => o.StandardIncome() + o.RemoteMiningIncome() + o.RawResourceIncome();
 
-		public static object Instantiate(this Type type, params object[] args)
+		public static object? Instantiate(this Type type, params object[] args)
 		{
 			if (type.Name == "Battle")
 				return typeof(SpaceBattle).Instantiate(); // HACK - old savegame compatibility
@@ -704,15 +682,9 @@ namespace FrEee.Utility.Extensions
 				return FormatterServices.GetSafeUninitializedObject(type);
 		}
 
-		public static T Instantiate<T>(params object[] args)
-		{
-			return (T)typeof(T).Instantiate(args);
-		}
+		public static T Instantiate<T>(params object[] args) => (T)typeof(T).Instantiate(args);
 
-		public static bool IsUnlocked(this IUnlockable u)
-		{
-			return u.UnlockRequirements.All(r => r.IsMetBy(Empire.Current));
-		}
+		public static bool IsUnlocked(this IUnlockable u) => u.UnlockRequirements.All(r => r.IsMetBy(Empire.Current));
 
 		/// <summary>
 		/// Limits a value to a range.
@@ -725,7 +697,7 @@ namespace FrEee.Utility.Extensions
 		public static int LimitToRange(this int value, int min, int max)
 		{
 			if (min > max)
-				throw new ArgumentOutOfRangeException("Min is {0} and can't be larger than max which is {1}!".F(min, max));
+				throw new ArgumentOutOfRangeException($"Min is {min} and can't be larger than max which is {max}!");
 			if (value > max)
 				value = max;
 			if (value < min)
@@ -744,7 +716,7 @@ namespace FrEee.Utility.Extensions
 		public static double LimitToRange(this double value, double min, double max)
 		{
 			if (min > max)
-				throw new ArgumentOutOfRangeException("Min is {0} and can't be larger than max which is {1}!".F(min, max));
+				throw new ArgumentOutOfRangeException($"Min is {min} and can't be larger than max which is {max}!");
 			if (value > max)
 				value = max;
 			if (value < min)

--- a/FrEee/Utility/Extensions/CommonExtensions.cs
+++ b/FrEee/Utility/Extensions/CommonExtensions.cs
@@ -1099,7 +1099,7 @@ namespace FrEee.Utility.Extensions
 		}
 
 		public static GalaxyReference<T> ReferViaGalaxy<T>(this T t)
-			where T : IReferrable
+			where T : class, IReferrable
 		{
 			if (t == null)
 				return null;

--- a/FrEee/Utility/Extensions/ComparisonExtensions.cs
+++ b/FrEee/Utility/Extensions/ComparisonExtensions.cs
@@ -1,7 +1,9 @@
-﻿using FrEee.Game.Objects.Space;
+using FrEee.Game.Objects.Space;
 using FrEee.Modding.Interfaces;
 using System;
 using System.Globalization;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {

--- a/FrEee/Utility/Extensions/ConversionExtensions.cs
+++ b/FrEee/Utility/Extensions/ConversionExtensions.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Modding.Interfaces;
+using FrEee.Modding.Interfaces;
 using System;
 using System.Drawing;
 using System.Globalization;
 using System.Text;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {
@@ -38,9 +40,9 @@ namespace FrEee.Utility.Extensions
 		/// <typeparam name="T"></typeparam>
 		/// <param name="o"></param>
 		/// <returns></returns>
-		public static T CastTo<T>(this object o, T defaultValue = default(T))
+		public static T? CastTo<T>(this object o, T defaultValue = default(T))
 		{
-			return (T)((o ?? defaultValue) ?? default(T));
+			return (T?)((o ?? defaultValue) ?? default(T));
 		}
 
 		/// <summary>
@@ -144,7 +146,7 @@ namespace FrEee.Utility.Extensions
 			return new Point(v.X, v.Y);
 		}
 
-		public static string ToSafeString(this object o)
+		public static string? ToSafeString(this object o)
 		{
 			if (o == null)
 				return null;

--- a/FrEee/Utility/Extensions/CopyingExtensions.cs
+++ b/FrEee/Utility/Extensions/CopyingExtensions.cs
@@ -1,12 +1,15 @@
-﻿using FrEee.Game.Interfaces;
-using FrEee.Game.Objects.Technology;
-using Omu.ValueInjecter;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+
+using FrEee.Game.Interfaces;
+using FrEee.Game.Objects.Technology;
+
+using Omu.ValueInjecter;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {
@@ -60,7 +63,7 @@ namespace FrEee.Utility.Extensions
 		/// <typeparam name="T">The type of object to copy.</typeparam>
 		/// <param name="obj">The object to copy.</param>
 		/// <returns>The copy.</returns>
-		public static T Copy<T>(this T obj)
+		public static T? Copy<T>(this T obj)
 		{
 			if (obj == null)
 				return default(T);
@@ -76,7 +79,7 @@ namespace FrEee.Utility.Extensions
 		/// <typeparam name="T"></typeparam>
 		/// <param name="obj"></param>
 		/// <returns></returns>
-		public static T CopyAndAssignNewID<T>(this T obj)
+		public static T? CopyAndAssignNewID<T>(this T obj)
 		{
 			if (obj == null)
 				return default(T);
@@ -111,7 +114,7 @@ namespace FrEee.Utility.Extensions
 
 		private class OnlySafePropertiesInjection : ConventionInjection
 		{
-			public OnlySafePropertiesInjection(object root, bool deep, IDCopyBehavior rootBehavior, IDCopyBehavior subordinateBehavior, IDictionary<object, object> known = null)
+			public OnlySafePropertiesInjection(object root, bool deep, IDCopyBehavior rootBehavior, IDCopyBehavior subordinateBehavior, IDictionary<object, object>? known = null)
 			{
 				Root = root;
 				DeepCopy = deep;
@@ -170,7 +173,7 @@ namespace FrEee.Utility.Extensions
 								}
 							}
 
-							object sv = null;
+							object? sv = null;
 
 							if (doit && CanCopyFully(sp) && DeepCopy)
 							{
@@ -207,8 +210,8 @@ namespace FrEee.Utility.Extensions
 						}
 					}
 				}
-				if (target is ICleanable)
-					(target as ICleanable).Clean();
+				if (target is ICleanable cleanable)
+					cleanable.Clean();
 			}
 
 			protected override bool Match(ConventionInfo c)
@@ -219,7 +222,7 @@ namespace FrEee.Utility.Extensions
 					c.Target.Type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Any(p => PropertyMatches(p, c.TargetProp.Name));
 			}
 
-			private object CopyObject(object parent, object sv)
+			private object? CopyObject(object parent, object? sv)
 			{
 				if (sv == null)
 					return null;
@@ -280,7 +283,7 @@ namespace FrEee.Utility.Extensions
 							var skv = skvp.GetPropertyValue("Value");
 							var tk = CopyObject(sv, sk);
 							var tkv = CopyObject(sv, skv);
-							adder.Invoke(tc, new object[] { tk, tkv });
+							adder.Invoke(tc, new object?[] { tk, tkv });
 						}
 					}
 					else

--- a/FrEee/Utility/Extensions/EnumerableExtensions.cs
+++ b/FrEee/Utility/Extensions/EnumerableExtensions.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {
@@ -44,26 +46,26 @@ namespace FrEee.Utility.Extensions
 			return -1;
 		}
 
-		public static T MaxOrDefault<T>(this IEnumerable<T> stuff)
+		public static T? MaxOrDefault<T>(this IEnumerable<T> stuff)
 		{
 			if (!stuff.Any())
 				return default(T);
 			return stuff.Max();
 		}
 
-		public static TProp MaxOrDefault<TItem, TProp>(this IEnumerable<TItem> stuff, Func<TItem, TProp> selector)
+		public static TProp? MaxOrDefault<TItem, TProp>(this IEnumerable<TItem> stuff, Func<TItem, TProp> selector)
 		{
 			return stuff.Select(selector).MaxOrDefault();
 		}
 
-		public static T MinOrDefault<T>(this IEnumerable<T> stuff)
+		public static T? MinOrDefault<T>(this IEnumerable<T> stuff)
 		{
 			if (!stuff.Any())
 				return default(T);
 			return stuff.Min();
 		}
 
-		public static TProp MinOrDefault<TItem, TProp>(this IEnumerable<TItem> stuff, Func<TItem, TProp> selector)
+		public static TProp? MinOrDefault<TItem, TProp>(this IEnumerable<TItem> stuff, Func<TItem, TProp> selector)
 		{
 			return stuff.Select(selector).MinOrDefault();
 		}
@@ -76,7 +78,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="item"></param>
 		/// <param name="wrap"></param>
 		/// <returns></returns>
-		public static T Next<T>(this IEnumerable<T> list, T item, bool wrap = false)
+		public static T? Next<T>(this IEnumerable<T> list, T item, bool wrap = false)
 		{
 			var index = list.IndexOf(item) + 1;
 			if (index >= list.Count())
@@ -109,7 +111,7 @@ namespace FrEee.Utility.Extensions
 		/// <typeparam name="T"></typeparam>
 		/// <param name="src"></param>
 		/// <returns></returns>
-		public static T PickRandom<T>(this IEnumerable<T> src, PRNG prng = null)
+		public static T? PickRandom<T>(this IEnumerable<T> src, PRNG? prng = null)
 		{
 			if (!src.Any())
 				return default(T);
@@ -122,11 +124,11 @@ namespace FrEee.Utility.Extensions
 		/// <typeparam name="T"></typeparam>
 		/// <param name="src"></param>
 		/// <returns></returns>
-		public static T PickWeighted<T>(this IDictionary<T, int> src, PRNG prng = null)
+		public static T? PickWeighted<T>(this IDictionary<T, int> src, PRNG? prng = null)
 		{
 			var total = src.Sum(kvp => kvp.Value);
 			int num;
-			if (prng == null)
+			if (prng is null)
 				num = RandomHelper.Next(total);
 			else
 				num = prng.Next(total);
@@ -147,11 +149,11 @@ namespace FrEee.Utility.Extensions
 		/// <typeparam name="T"></typeparam>
 		/// <param name="src"></param>
 		/// <returns></returns>
-		public static T PickWeighted<T>(this IDictionary<T, long> src, PRNG prng = null)
+		public static T? PickWeighted<T>(this IDictionary<T, long> src, PRNG? prng = null)
 		{
 			var total = src.Sum(kvp => kvp.Value);
 			long num;
-			if (prng == null)
+			if (prng is null)
 				num = RandomHelper.Next(total);
 			else
 				num = prng.Next(total);
@@ -171,11 +173,11 @@ namespace FrEee.Utility.Extensions
 		/// <typeparam name="T"></typeparam>
 		/// <param name="src"></param>
 		/// <returns></returns>
-		public static T PickWeighted<T>(this IDictionary<T, double> src, PRNG prng = null)
+		public static T? PickWeighted<T>(this IDictionary<T, double> src, PRNG? prng = null)
 		{
 			var total = src.Sum(kvp => kvp.Value);
 			double num;
-			if (prng == null)
+			if (prng is null)
 				num = RandomHelper.Next(total);
 			else
 				num = prng.Next(total);
@@ -189,17 +191,17 @@ namespace FrEee.Utility.Extensions
 			return default(T); // nothing to pick...
 		}
 
-		public static T PickWeighted<T>(this IEnumerable<T> src, Func<T, int> weighter, PRNG prng = null)
+		public static T? PickWeighted<T>(this IEnumerable<T> src, Func<T, int> weighter, PRNG? prng = null)
 		{
 			return src.ToDictionary(x => x, x => weighter(x)).PickWeighted(prng);
 		}
 
-		public static T PickWeighted<T>(this IEnumerable<T> src, Func<T, long> weighter, PRNG prng = null)
+		public static T? PickWeighted<T>(this IEnumerable<T> src, Func<T, long> weighter, PRNG? prng = null)
 		{
 			return src.ToDictionary(x => x, x => weighter(x)).PickWeighted(prng);
 		}
 
-		public static T PickWeighted<T>(this IEnumerable<T> src, Func<T, double> weighter, PRNG prng = null)
+		public static T? PickWeighted<T>(this IEnumerable<T> src, Func<T, double> weighter, PRNG? prng = null)
 		{
 			return src.ToDictionary(x => x, x => weighter(x)).PickWeighted(prng);
 		}
@@ -212,7 +214,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="item"></param>
 		/// <param name="wrap"></param>
 		/// <returns></returns>
-		public static T Previous<T>(this IEnumerable<T> list, T item, bool wrap = false)
+		public static T? Previous<T>(this IEnumerable<T> list, T item, bool wrap = false)
 		{
 			var index = list.IndexOf(item) - 1;
 			if (index < 0)
@@ -245,7 +247,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="src"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> src, PRNG prng = null)
+		public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> src, PRNG? prng = null)
 		{
 			return src.Select(value => (RandomHelper.Next(int.MaxValue, prng), value)).OrderBy(q => q.Item1).Select(q => q.value);
 		}
@@ -303,7 +305,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="src"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> ThenShuffle<T>(this IOrderedEnumerable<T> src, PRNG prng = null)
+		public static IEnumerable<T> ThenShuffle<T>(this IOrderedEnumerable<T> src, PRNG? prng = null)
 		{
 			return src.ThenBy(t => RandomHelper.Next(int.MaxValue, prng));
 		}

--- a/FrEee/Utility/Extensions/GameEnumerableExtensions.cs
+++ b/FrEee/Utility/Extensions/GameEnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
@@ -8,6 +8,8 @@ using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Space;
 using FrEee.Modding;
 using FrEee.Modding.Interfaces;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {
@@ -23,7 +25,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="list"></param>
 		/// <param name="emp"></param>
 		/// <returns></returns>
-		public static IEnumerable<T> BelongingTo<T>(this IEnumerable<T> list, Empire emp) where T : IOwnable
+		public static IEnumerable<T> BelongingTo<T>(this IEnumerable<T> list, Empire? emp) where T : IOwnable
 		{
 			return list.Where(t => t.Owner == emp);
 		}
@@ -49,7 +51,7 @@ namespace FrEee.Utility.Extensions
 			return stuff.Where(item => item.Name == name);
 		}
 
-		public static T FindByModID<T>(this IEnumerable<T> items, string modID)
+		public static T? FindByModID<T>(this IEnumerable<T> items, string modID)
 							where T : IModObject
 		{
 			if (modID == null)
@@ -63,24 +65,24 @@ namespace FrEee.Utility.Extensions
 			return result;
 		}
 
-		public static T FindByName<T>(this IEnumerable<T> stuff, string name) where T : INamed
+		public static T? FindByName<T>(this IEnumerable<T> stuff, string name) where T : INamed
 		{
 			return stuff.FirstOrDefault(item => item.Name == name);
 		}
 
-		public static TValue FindByName<TKey, TValue>(this IDictionary<TKey, TValue> dict, string name)
+		public static TValue? FindByName<TKey, TValue>(this IDictionary<TKey, TValue> dict, string name)
 							where TKey : INamed
 		{
 			return dict[dict.Keys.FindByName(name)];
 		}
 
-		public static T FindByTypeNameIndex<T>(this IEnumerable<T> items, Type type, string name, int index)
+		public static T? FindByTypeNameIndex<T>(this IEnumerable<T> items, Type type, string name, int index)
 							where T : IModObject
 		{
 			return items.Where(item => item.GetType() == type && item.Name == name).ElementAtOrDefault(index);
 		}
 
-		public static T FindMatch<T>(this IEnumerable<T> items, T nu, IEnumerable<T> nuItems)
+		public static T? FindMatch<T>(this IEnumerable<T> items, T nu, IEnumerable<T> nuItems)
 							where T : class, IModObject
 		{
 			return items.FindByModID(nu.ModID) ?? items.FindByTypeNameIndex(nu.GetType(), nu.Name, nuItems.GetIndex(nu));
@@ -106,7 +108,7 @@ namespace FrEee.Utility.Extensions
 		/// </summary>
 		/// <param name="objects">The group of space objects.</param>
 		/// <returns>The largest space object.</returns>
-		public static ISpaceObject Largest(this IEnumerable<ISpaceObject> objects)
+		public static ISpaceObject? Largest(this IEnumerable<ISpaceObject> objects)
 		{
 			if (objects.OfType<Star>().Any())
 			{
@@ -143,7 +145,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="src"></param>
 		/// <param name="selector"></param>
 		/// <returns></returns>
-		public static TCompared Majority<T, TCompared>(this IEnumerable<T> src, Func<T, TCompared> selector)
+		public static TCompared? Majority<T, TCompared>(this IEnumerable<T> src, Func<T, TCompared> selector)
 		{
 			var groups = src.GroupBy(x => selector(x));
 			groups = groups.WithMax(g => g.Count());
@@ -210,11 +212,11 @@ namespace FrEee.Utility.Extensions
 			}
 		}
 
-		public static IEnumerable<T> OnlyLatestVersions<T>(this IEnumerable<T> stuff, Func<T, string> familySelector)
+		public static IEnumerable<T?> OnlyLatestVersions<T>(this IEnumerable<T> stuff, Func<T, string> familySelector)
 					where T : class
 		{
-			string family = null;
-			T latest = null;
+			string? family = null;
+			T? latest = null;
 			foreach (var t in stuff)
 			{
 				if (family == null)

--- a/FrEee/Utility/Extensions/MathExtensions.cs
+++ b/FrEee/Utility/Extensions/MathExtensions.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {
@@ -14,7 +16,7 @@ namespace FrEee.Utility.Extensions
 		/// <param name="num">The number.</param>
 		/// <param name="decimalPlaces">The decimal places.</param>
 		/// <returns></returns>
-		public static string CeilingString(this double? num, int decimalPlaces = 0)
+		public static string? CeilingString(this double? num, int decimalPlaces = 0)
 		{
 			if (num == null)
 				return null;

--- a/FrEee/Utility/Extensions/Parser.cs
+++ b/FrEee/Utility/Extensions/Parser.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {

--- a/FrEee/Utility/Extensions/StringHandlingExtensions.cs
+++ b/FrEee/Utility/Extensions/StringHandlingExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {
@@ -9,7 +11,7 @@ namespace FrEee.Utility.Extensions
 			return s[0].ToString().ToLowerInvariant() + s.Substring(1);
 		}
 
-		public static string Capitalize(this string s)
+		public static string? Capitalize(this string s)
 		{
 			if (s == null)
 				return null;
@@ -44,7 +46,7 @@ namespace FrEee.Utility.Extensions
 			return string.Format(format, args);
 		}
 
-		public static string LastWord(this string s)
+		public static string? LastWord(this string s)
 		{
 			if (s == null)
 				return null;

--- a/FrEee/Utility/Extensions/UnitHandlingExtensions.cs
+++ b/FrEee/Utility/Extensions/UnitHandlingExtensions.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Utility.Extensions
 {

--- a/FrEee/Utility/GalaxyReference.cs
+++ b/FrEee/Utility/GalaxyReference.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Space;
 using FrEee.Utility.Extensions;
 using System;
@@ -15,9 +15,8 @@ namespace FrEee.Utility
 	/// <typeparam name="T"></typeparam>
 	[Serializable]
 	public class GalaxyReference<T> : IReference<long, T>, IPromotable
-		where T : IReferrable
+		where T : class, IReferrable
 	{
-
 		/// <summary>
 		/// Either will create a new Galaxy Reference with the given id, or return null.
 		/// Useful to allow a client to store an ID locally for reference, when the server might destroy said ID. 

--- a/FrEee/Utility/GalaxyReference.cs
+++ b/FrEee/Utility/GalaxyReference.cs
@@ -4,6 +4,8 @@ using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace FrEee.Utility
 {
 	/// <summary>
@@ -23,7 +25,7 @@ namespace FrEee.Utility
 		/// </summary>
 		/// <param name="id"></param>
 		/// <returns></returns>
-		public static GalaxyReference<T> GetGalaxyReference(long id)
+		public static GalaxyReference<T>? GetGalaxyReference(long id)
 		{
 			if (Galaxy.Current.referrables.ContainsKey(id))
 				return new GalaxyReference<T>(id);
@@ -83,9 +85,9 @@ namespace FrEee.Utility
 			{
 				if (ID <= 0)
 					return value;
-				var obj = (T)Galaxy.Current.GetReferrable(ID);
+				var obj = (T?)Galaxy.Current.GetReferrable(ID);
 				if (obj == null)
-					return default(T);
+					return default;
 				/*if (obj is IReferrable && (obj as IReferrable).IsDisposed)
 					return default(T);*/
 				return obj;
@@ -104,40 +106,37 @@ namespace FrEee.Utility
 		/// Resolves the reference.
 		/// </summary>
 		/// <returns></returns>
-		public T Value
+		public T? Value
 		{
 			get
 			{
 				if (cache == null)
 					InitializeCache();
-				return cache.Value;
+				return cache?.Value;
 			}
 		}
 
 		[field: NonSerialized]
-		private T value { get; set; }
+		private T? value { get; set; }
 
 		[NonSerialized]
-		private ClientSideCache<T> cache;
+		private ClientSideCache<T>? cache;
 
-		public static implicit operator GalaxyReference<T>(T t)
+		public static implicit operator GalaxyReference<T>?(T t)
 		{
 			if (t == null)
 				return null;
 			return new GalaxyReference<T>(t);
 		}
 
-		public static implicit operator T(GalaxyReference<T> r)
+		public static implicit operator T?(GalaxyReference<T>? r)
 		{
-			if (r == null)
+			if (r is null)
 				return default(T);
 			return r.Value;
 		}
 
-		public static bool operator !=(GalaxyReference<T> r1, GalaxyReference<T> r2)
-		{
-			return !(r1 == r2);
-		}
+		public static bool operator !=(GalaxyReference<T> r1, GalaxyReference<T> r2) => !(r1 == r2);
 
 		public static bool operator ==(GalaxyReference<T> r1, GalaxyReference<T> r2)
 		{
@@ -148,7 +147,7 @@ namespace FrEee.Utility
 			return r1.ID == r2.ID;
 		}
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
 			// TODO - upgrade equals to use "as" operator
 			if (obj is GalaxyReference<T>)
@@ -156,12 +155,9 @@ namespace FrEee.Utility
 			return false;
 		}
 
-		public override int GetHashCode()
-		{
-			return ID.GetHashCode();
-		}
+		public override int GetHashCode() => ID.GetHashCode();
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();

--- a/FrEee/Utility/HashCodeMasher.cs
+++ b/FrEee/Utility/HashCodeMasher.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using System.Collections;
+
+#nullable enable
 
 namespace FrEee.Utility
 {

--- a/FrEee/Utility/HeatMap.cs
+++ b/FrEee/Utility/HeatMap.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Utility
+#nullable enable
+
+namespace FrEee.Utility
 {
 	/// <summary>
 	/// A heatmap, used for pathfinding and the like.
@@ -28,7 +30,7 @@
 
 		public IntVector2 FindMax(IntVector2 pos, int range)
 		{
-			IntVector2 result = null;
+			IntVector2? result = null;
 			for (var x = pos.X - range; x <= pos.X + range; x++)
 			{
 				for (var y = pos.Y - range; y <= pos.Y + range; y++)
@@ -42,7 +44,7 @@
 
 		public IntVector2 FindMin(IntVector2 pos, int range)
 		{
-			IntVector2 result = null;
+			IntVector2? result = null;
 			for (var x = pos.X - range; x <= pos.X + range; x++)
 			{
 				for (var y = pos.Y - range; y <= pos.Y + range; y++)

--- a/FrEee/Utility/IData.cs
+++ b/FrEee/Utility/IData.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
+
+#nullable enable
 
 namespace FrEee.Utility
 {

--- a/FrEee/Utility/IData.cs
+++ b/FrEee/Utility/IData.cs
@@ -15,6 +15,6 @@ namespace FrEee.Utility
 		string Data { get; set; }
 
 		[JsonIgnore]
-		object Value { get; }
+		object? Value { get; }
 	}
 }

--- a/FrEee/Utility/IDataObject.cs
+++ b/FrEee/Utility/IDataObject.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Utility
+#nullable enable
+
+namespace FrEee.Utility
 {
 	/// <summary>
 	/// Used for abstract classes that want to define serialization data without requiring inherited classes use said data.

--- a/FrEee/Utility/IntVector2.cs
+++ b/FrEee/Utility/IntVector2.cs
@@ -1,8 +1,9 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -60,7 +61,7 @@ namespace FrEee.Utility
 		/// <param name="distance"></param>
 		/// <param name="skip">Should we skip moving to the endpoint? (say because it is occupied...)</param>
 		/// <returns></returns>
-		public static IntVector2 InterpolateEightWay(IntVector2 start, IntVector2 end, int distance, Func<IntVector2, bool> skip = null)
+		public static IntVector2 InterpolateEightWay(IntVector2 start, IntVector2 end, int distance, Func<IntVector2, bool>? skip = null)
 		{
 			if (distance <= 0)
 				return start;
@@ -143,16 +144,16 @@ namespace FrEee.Utility
 			return (dest - this).LengthManhattan;
 		}
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
 			if (obj is IntVector2 v)
 				return this.Equals(v);
 			return false;
 		}
 
-		public bool Equals(IntVector2 other)
+		public bool Equals(IntVector2? other)
 		{
-			return X == other.X && Y == other.Y;
+			return X == other?.X && Y == other?.Y;
 		}
 
 		public override int GetHashCode()

--- a/FrEee/Utility/JsonContractResolver.cs
+++ b/FrEee/Utility/JsonContractResolver.cs
@@ -1,15 +1,14 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
-    public class JsonContractResolver : DefaultContractResolver
+	public class JsonContractResolver : DefaultContractResolver
     {
 
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)

--- a/FrEee/Utility/JsonSerializer.cs
+++ b/FrEee/Utility/JsonSerializer.cs
@@ -1,8 +1,10 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -22,7 +24,7 @@ namespace FrEee.Utility
 			};
 		}
 
-		public object DeserializeFromString(string s)
+		public object? DeserializeFromString(string s)
 		{
 			var list = JsonConvert.DeserializeObject<List<object>>(s);
 			if (list.Count == 0)
@@ -31,35 +33,33 @@ namespace FrEee.Utility
 			if (first == null)
 				return null;
 			// TODO - make IData and ISimpleDataObject implement a common interface
-			if (first is ISimpleDataObject)
+			if (first is ISimpleDataObject f)
 			{
-				var f = first as ISimpleDataObject;
 				foreach (var item in list)
 				{
-					if (item is ISimpleDataObject)
+					if (item is ISimpleDataObject dobj)
 					{
-						var dobj = item as ISimpleDataObject;
 						dobj.Context = f.Context;
 						foreach (var r in dobj.SimpleData.Values.OfType<IDataReference>())
 							r.Context = f.Context;
 					}
-					if (item is IData)
-						f.Context.Add((item as IData).Value);
+					if (item is IData data)
+						f.Context.Add(data.Value);
 				}
 			}
 			foreach (var item in list.OfType<ISimpleDataObject>())
 				item.InitializeValue();
-			if (first is ISimpleDataObject)
-				return (first as ISimpleDataObject).Value;
-			if (first is IData)
-				return (first as IData).Value;
+			if (first is ISimpleDataObject fsdo)
+				return fsdo.Value;
+			if (first is IData fData)
+				return fData.Value;
 			return first;
 		}
 
 		public string SerializeToString(object o)
 		{
 			var ctx = new ObjectGraphContext();
-			var kos = new List<object>();
+			var kos = new List<object?>();
 			var parser = new ObjectGraphParser();
 			if (o == null)
 			{
@@ -112,7 +112,7 @@ namespace FrEee.Utility
 		/// <typeparam name="T"></typeparam>
 		/// <param name="json"></param>
 		/// <returns></returns>
-		public static T DeserializeObject<T>(string json)
+		public static T? DeserializeObject<T>(string json)
 		{
 			return JsonConvert.DeserializeObject<T>(json, SimpleConverterSettings); 
 		}

--- a/FrEee/Utility/LegacySerializer.cs
+++ b/FrEee/Utility/LegacySerializer.cs
@@ -38,7 +38,7 @@ namespace FrEee.Utility
 
 		internal static T Deserialize<T>(TextReader r, ObjectGraphContext context = null)
 		{
-			return (T)LegacySerializer.Deserialize(r, typeof(T), true, context);
+			return (T)Deserialize(r, typeof(T), true, context);
 		}
 
 		internal static void Serialize<T>(T o, TextWriter w, ObjectGraphContext context = null, int tabLevel = 0)
@@ -184,7 +184,7 @@ namespace FrEee.Utility
 
 						type = new SafeType(typename).Type;
 					}
-					catch (Exception ex)
+					catch (Exception)
 					{
 						try
 						{

--- a/FrEee/Utility/LegacySerializer.cs
+++ b/FrEee/Utility/LegacySerializer.cs
@@ -1,5 +1,4 @@
 using FrEee.Game.Interfaces;
-using FrEee.Game.Objects.Civilization;
 using FrEee.Utility.Extensions;
 using FrEee.Utility.Stringifiers;
 using System;
@@ -15,13 +14,15 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace FrEee.Utility
 {
 	internal static class LegacySerializer
 	{
 		private static IList<Task> propertySetterTasks = new List<Task>();
 
-		public static object Deserialize(Stream s, Type desiredType, ObjectGraphContext context = null, StringBuilder log = null)
+		public static object? Deserialize(Stream s, Type desiredType, ObjectGraphContext? context = null, StringBuilder? log = null)
 		{
 			var sr = new StreamReader(s);
 			var result = Deserialize(sr, desiredType, true, context, log);
@@ -29,19 +30,19 @@ namespace FrEee.Utility
 			return result;
 		}
 
-		internal static T Deserialize<T>(Stream s, ObjectGraphContext context = null)
+		internal static T? Deserialize<T>(Stream s, ObjectGraphContext? context = null)
 		{
 			var sr = new StreamReader(new BufferedStream(s));
 			var result = Deserialize<T>(sr, context);
 			return result;
 		}
 
-		internal static T Deserialize<T>(TextReader r, ObjectGraphContext context = null)
+		internal static T? Deserialize<T>(TextReader r, ObjectGraphContext? context = null)
 		{
-			return (T)Deserialize(r, typeof(T), true, context);
+			return (T?)Deserialize(r, typeof(T), true, context);
 		}
 
-		internal static void Serialize<T>(T o, TextWriter w, ObjectGraphContext context = null, int tabLevel = 0)
+		internal static void Serialize<T>(T o, TextWriter w, ObjectGraphContext? context = null, int tabLevel = 0)
 		{
 			if (o == null)
 				Serialize(o, w, typeof(T), context, tabLevel);
@@ -54,7 +55,7 @@ namespace FrEee.Utility
 			return SafeType.GetShortTypeName(t);
 		}
 
-		internal static void Serialize(object o, TextWriter w, Type desiredType, ObjectGraphContext context = null, int tabLevel = 0)
+		internal static void Serialize(object? o, TextWriter w, Type desiredType, ObjectGraphContext? context = null, int tabLevel = 0)
 		{
 			var tabs = new string('\t', tabLevel);
 
@@ -153,7 +154,7 @@ namespace FrEee.Utility
 				w.Flush();
 		}
 
-		private static object Deserialize(TextReader r, Type desiredType, bool isRoot, ObjectGraphContext context = null, StringBuilder log = null)
+		private static object? Deserialize(TextReader r, Type desiredType, bool isRoot, ObjectGraphContext? context = null, StringBuilder? log = null)
 		{
 			// set up our serialization context if we haven't already
 			if (context == null)
@@ -219,7 +220,7 @@ namespace FrEee.Utility
 			}
 
 			// the object!
-			object o;
+			object? o;
 
 			if (StringifierLibrary.Instance.All?.Any(x => x.SupportedType.IsAssignableFrom(type)) ?? false)
 			{
@@ -280,10 +281,10 @@ namespace FrEee.Utility
 			return o;
 		}
 
-		private static Array DeserializeArray(TextReader r, Type type, ObjectGraphContext context, StringBuilder log)
+		private static Array? DeserializeArray(TextReader r, Type type, ObjectGraphContext context, StringBuilder? log)
 		{
 			// arrays
-			Array o;
+			Array? o;
 			// read bounds or id number
 			var fin = r.Read();
 			while (fin != 0 && char.IsWhiteSpace((char)fin))
@@ -371,7 +372,7 @@ namespace FrEee.Utility
 			return o;
 		}
 
-		private static IEnumerable DeserializeDictionary(TextReader r, Type type, ObjectGraphContext context, StringBuilder log)
+		private static IEnumerable DeserializeDictionary(TextReader r, Type type, ObjectGraphContext context, StringBuilder? log)
 		{
 			IEnumerable o;
 			int size;
@@ -388,7 +389,7 @@ namespace FrEee.Utility
 				itemType = typeof(KeyValuePair<object, object>);
 			else
 				// HACK - Resources inherits from a dictionary type
-				itemType = typeof(KeyValuePair<,>).MakeGenericType(type.BaseType.GetGenericArguments());
+				itemType = typeof(KeyValuePair<,>).MakeGenericType(type.BaseType?.GetGenericArguments());
 
 			var collParm = Expression.Parameter(typeof(object), "coll");
 			var keyParm = Expression.Parameter(typeof(object), "key");
@@ -427,9 +428,9 @@ namespace FrEee.Utility
 			return o;
 		}
 
-		private static IEnumerable DeserializeList(TextReader r, Type type, ObjectGraphContext context, StringBuilder log)
+		private static IEnumerable? DeserializeList(TextReader r, Type type, ObjectGraphContext context, StringBuilder? log)
 		{
-			IEnumerable o;
+			IEnumerable? o;
 			int size;
 			var sizeStr = r.ReadTo(':', log);
 			if (!int.TryParse(sizeStr, out size))
@@ -487,7 +488,7 @@ namespace FrEee.Utility
 				var item = Deserialize(r, itemType, false, context, log);
 				lambdaAdder.DynamicInvoke(coll, item);
 			}
-			o = (IEnumerable)coll;
+			o = (IEnumerable?)coll;
 
 			// clean up
 			ReadSemicolon(r, type, log);
@@ -495,9 +496,9 @@ namespace FrEee.Utility
 			return o;
 		}
 
-		private static IEnumerable DeserializeCollection(TextReader r, Type type, ObjectGraphContext context, StringBuilder log)
+		private static IEnumerable? DeserializeCollection(TextReader r, Type type, ObjectGraphContext context, StringBuilder? log)
 		{
-			IEnumerable o = null;
+			IEnumerable? o = null;
 			// collections
 			// read size or id number
 			var fin = r.Read();
@@ -549,9 +550,9 @@ namespace FrEee.Utility
 			return o;
 		}
 
-		private static object DeserializeStringifiedObject(TextReader r, Type type, ObjectGraphContext context, StringBuilder log)
+		private static object? DeserializeStringifiedObject(TextReader r, Type type, ObjectGraphContext context, StringBuilder? log)
 		{
-			object o;
+			object? o;
 			// read tag to see if it's actually a stringified object
 			var fin = r.Read();
 			while (fin != 0 && char.IsWhiteSpace((char)fin))
@@ -564,7 +565,7 @@ namespace FrEee.Utility
 				log.Append((char)fin);
 			if (fin == 's')
 			{
-				IStringifier stringifier = null;
+				IStringifier? stringifier = null;
 				var t = type;
 				while (stringifier == null && t != null)
 				{
@@ -608,7 +609,7 @@ namespace FrEee.Utility
 			return o;
 		}
 
-		private static object DeserializeObjectWithProperties(TextReader r, Type type, ObjectGraphContext context, StringBuilder log)
+		private static object DeserializeObjectWithProperties(TextReader r, Type type, ObjectGraphContext context, StringBuilder? log)
 		{
 			// create object and add it to our context
 			var o = type.Instantiate();
@@ -621,7 +622,7 @@ namespace FrEee.Utility
 				throw new SerializationException("Expected integer, got \"" + s + "\" when parsing property count.");
 
 
-			var dict = new SafeDictionary<string, object>();
+			var dict = new SafeDictionary<string, object?>();
 
 			// deserialize the properties
 			var props = ObjectGraphContext.GetKnownProperties(type, true);
@@ -665,7 +666,7 @@ namespace FrEee.Utility
 			return o;
 		}
 
-		private static object DeserializeObjectWithID(TextReader r, Type type, ObjectGraphContext context, StringBuilder log)
+		private static object DeserializeObjectWithID(TextReader r, Type type, ObjectGraphContext context, StringBuilder? log)
 		{
 			// ID - need to find known object
 			int id;
@@ -681,10 +682,10 @@ namespace FrEee.Utility
 			return context.KnownObjects[type][id];
 		}
 
-		private static object DeserializeObject(TextReader r, Type type, ObjectGraphContext context, StringBuilder log)
+		private static object? DeserializeObject(TextReader r, Type type, ObjectGraphContext context, StringBuilder? log)
 		{
 			// read property count or id number
-			object o;
+			object? o;
 			var fin = r.Read();
 			while (fin != 0 && char.IsWhiteSpace((char)fin))
 			{
@@ -713,9 +714,9 @@ namespace FrEee.Utility
 			return o;
 		}
 
-		private static string DeserializeString(TextReader r, ObjectGraphContext context, StringBuilder log)
+		private static string? DeserializeString(TextReader r, ObjectGraphContext context, StringBuilder? log)
 		{
-			string o;
+			string? o;
 			bool foundRealSemicolon = false;
 			StringBuilder sb = new StringBuilder();
 			int quotes = 0;
@@ -750,7 +751,7 @@ namespace FrEee.Utility
 			return int.MaxValue;
 		}
 
-		private static void ReadSemicolon(TextReader r, Type type, StringBuilder log)
+		private static void ReadSemicolon(TextReader r, Type type, StringBuilder? log)
 		{
 			// read the semicolon at the end and any whitespace
 			int ender;
@@ -764,7 +765,7 @@ namespace FrEee.Utility
 			} while (ender != ';');
 		}
 
-		private static void Serialize<T>(T o, Stream s, ObjectGraphContext context = null, int tabLevel = 0)
+		private static void Serialize<T>(T o, Stream s, ObjectGraphContext? context = null, int tabLevel = 0)
 		{
 			var sw = new StreamWriter(new BufferedStream(s));
 			Serialize(o, sw, context);
@@ -819,7 +820,7 @@ namespace FrEee.Utility
 				w.WriteLine("d" + list.Cast<object>().Count() + ":" + tabs);
 				isDict = true;
 			}
-			else if (type.BaseType.GetGenericArguments().Length == 2)
+			else if (type.BaseType?.GetGenericArguments().Length == 2)
 			{
 				// HACK - Resources inherits from a dictionary type
 				itemType = typeof(KeyValuePair<,>).MakeGenericType(type.BaseType.GetGenericArguments());
@@ -879,11 +880,11 @@ namespace FrEee.Utility
 		private static void WriteObject(object o, TextWriter w, ObjectGraphContext context, int tabLevel)
 		{
 			// serialize object type and field count
-			if (o is IDataObject)
+			if (o is IDataObject dataObject)
 			{
 				// use data object code! :D
 				var type = o.GetType();
-				var data = (o as IDataObject).Data;
+				var data = dataObject.Data;
 				w.WriteLine("p" + data.Count + ":");
 				foreach (var kvp in data)
 				{
@@ -964,7 +965,7 @@ namespace FrEee.Utility
 
 		private static void WriteStringifiedObject(object o, TextWriter w)
 		{
-			IStringifier stringifier = null;
+			IStringifier? stringifier = null;
 			var t = o.GetType();
 			while (stringifier == null && t != null)
 			{

--- a/FrEee/Utility/Library.cs
+++ b/FrEee/Utility/Library.cs
@@ -16,7 +16,7 @@ namespace FrEee.Utility
 	{
 		static Library()
 		{
-			Items = new HashSet<object>();
+			Items = new HashSet<object?>();
 		}
 
 		/// <summary>

--- a/FrEee/Utility/Library.cs
+++ b/FrEee/Utility/Library.cs
@@ -1,9 +1,11 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -31,7 +33,7 @@ namespace FrEee.Utility
 		/// <summary>
 		/// The items in the library.
 		/// </summary>
-		private static ISet<object> Items { get; set; }
+		private static ISet<object?> Items { get; set; }
 
 		/// <summary>
 		/// Deletes objects from the library.
@@ -39,7 +41,7 @@ namespace FrEee.Utility
 		/// <typeparam name="T">The type of object to delete.</typeparam>
 		/// <param name="condition">Condition to apply when selecting objects to delete.</param>
 		/// <returns>Number of objects deleted.</returns>
-		public static int Delete<T>(Func<T, bool> condition = null, bool autosave = true)
+		public static int Delete<T>(Func<T, bool>? condition = null, bool autosave = true)
 		{
 			// defaults to deleting all
 			if (condition == null)
@@ -64,7 +66,7 @@ namespace FrEee.Utility
 		/// <param name="cleaner">Anything special to do to the copied object before saving it.</param>
 		/// <param name="autosave"></param>
 		/// <param name="o"></param>
-		public static void Export<T>(T o, Action<T> cleaner = null, bool autosave = true)
+		public static void Export<T>(T o, Action<T>? cleaner = null, bool autosave = true)
 		{
 			var c = o.CopyAndAssignNewID();
 			// TODO - unassign ID in galaxy? does it matter?
@@ -81,7 +83,7 @@ namespace FrEee.Utility
 		/// <typeparam name="T">The type of object to import.</typeparam>
 		/// <param name="condition">Condition to apply when selecting objects to import.</param>
 		/// <returns>Copied objects imported.</returns>
-		public static IEnumerable<T> Import<T>(Func<T, bool> condition = null)
+		public static IEnumerable<T> Import<T>(Func<T, bool>? condition = null)
 		{
 			// defaults to loading all
 			if (condition == null)
@@ -101,20 +103,20 @@ namespace FrEee.Utility
 					File.Move("Library.dat", FilePath);
 
 				var fs = File.OpenRead(FilePath);
-				Items = Serializer.Deserialize<ISet<object>>(fs);
+				Items = Serializer.Deserialize<ISet<object?>>(fs);
 				fs.Close(); fs.Dispose();
 			}
 			catch (IOException)
 			{
 				// file not found, leave library empty
 				// TODO - log somewhere?
-				Items = new HashSet<object>();
+				Items = new HashSet<object?>();
 			}
 			catch (SerializationException)
 			{
 				// bad data, leave library empty
 				// TODO - log somewhere?
-				Items = new HashSet<object>();
+				Items = new HashSet<object?>();
 			}
 		}
 

--- a/FrEee/Utility/MathX.cs
+++ b/FrEee/Utility/MathX.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
+
+#nullable enable
 
 namespace FrEee.Utility
 {

--- a/FrEee/Utility/MiningModel.cs
+++ b/FrEee/Utility/MiningModel.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.Utility
+#nullable enable
+
+namespace FrEee.Utility
 {
 	/// <summary>
 	/// A model for how resources should be mined.
@@ -21,8 +23,8 @@
 		/// </summary>
 		public double Rate
 		{
-			get { return RatePercentage / 100d; }
-			set { RatePercentage = value * 100d; }
+			get => RatePercentage / 100d;
+			set => RatePercentage = value * 100d;
 		}
 
 		/// <summary>
@@ -35,8 +37,8 @@
 		/// </summary>
 		public double ValueBonus
 		{
-			get { return ValuePercentageBonus / 100d; }
-			set { ValuePercentageBonus = value * 100d; }
+			get => ValuePercentageBonus / 100d;
+			set => ValuePercentageBonus = value * 100d;
 		}
 
 		/// <summary>

--- a/FrEee/Utility/NameAttribute.cs
+++ b/FrEee/Utility/NameAttribute.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+
+#nullable enable
 
 namespace FrEee.Utility
 {

--- a/FrEee/Utility/ObjectGraphParser.cs
+++ b/FrEee/Utility/ObjectGraphParser.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -6,6 +6,8 @@ using System.Drawing;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -96,7 +98,7 @@ namespace FrEee.Utility
 		public IEnumerable<string> PropertyStack { get { return propertyStack; } }
 
 		[field: NonSerialized]
-		internal Queue<object> ObjectQueue { get; set; }
+		internal Queue<object?> ObjectQueue { get; set; }
 
 		[NonSerialized]
 		internal Stack<object> objectStack;
@@ -212,7 +214,7 @@ namespace FrEee.Utility
 			return null;
 		}
 
-		public object GetObjectProperty(object obj, PropertyInfo prop)
+		public object? GetObjectProperty(object obj, PropertyInfo prop)
 		{
 			AddProperties(obj.GetType());
 			// lambda expressions don't seem to work on structs
@@ -261,7 +263,7 @@ namespace FrEee.Utility
 
 			public static ReferenceEqualityComparer Instance { get; private set; }
 
-			public new bool Equals(object x, object y)
+			public new bool Equals(object? x, object? y)
 			{
 				return ReferenceEquals(x, y);
 			}
@@ -278,7 +280,7 @@ namespace FrEee.Utility
 	/// </summary>
 	public class ObjectGraphParser
 	{
-		public IDictionary<Type, IList<object>> Parse(object o, ObjectGraphContext context = null)
+		public IDictionary<Type, IList<object>> Parse(object? o, ObjectGraphContext? context = null)
 		{
 			// set up our context if we haven't already
 			if (context == null)
@@ -409,7 +411,7 @@ namespace FrEee.Utility
 			}
 		}
 
-		private void ParseProperty(string propertyName, object o, object val, ObjectGraphContext context)
+		private void ParseProperty(string propertyName, object o, object? val, ObjectGraphContext context)
 		{
 			context.propertyStack.Push(propertyName);
 			bool recurse = true; // if no event handler, assume we are parsing recursively (really adding subproperties to queue)
@@ -425,37 +427,37 @@ namespace FrEee.Utility
 		/// <summary>
 		/// Raised when a new array is encountered.
 		/// </summary>
-		public event ArrayDimensionsDelegate ArrayDimensions;
+		public event ArrayDimensionsDelegate? ArrayDimensions;
 
 		/// <summary>
 		/// Raised when a new object is finished being parsed.
 		/// </summary>
-		public event ObjectDelegate EndObject;
+		public event ObjectDelegate? EndObject;
 
 		/// <summary>
 		/// Raised when an item in a collection is encountered.
 		/// </summary>
-		public event ObjectDelegate Item;
+		public event ObjectDelegate? Item;
 
 		/// <summary>
 		/// Raised when a previously encountered object is encountered again.
 		/// </summary>
-		public event ObjectDelegate KnownObject;
+		public event ObjectDelegate? KnownObject;
 
 		/// <summary>
 		/// Raised when a null reference is encountered.
 		/// </summary>
-		public event ObjectDelegate Null;
+		public event ObjectDelegate? Null;
 
 		/// <summary>
 		/// Raised when an object's property is encountered.
 		/// </summary>
-		public event PropertyDelegate Property;
+		public event PropertyDelegate? Property;
 
 		/// <summary>
 		/// Raised when a new object is encountered.
 		/// </summary>
-		public event ObjectDelegate StartObject;
+		public event ObjectDelegate? StartObject;
 
 		/// <summary>
 		/// Delegate for when an array's dimensions are encountered.
@@ -467,7 +469,7 @@ namespace FrEee.Utility
 		/// Delegate for when an object is encountered.
 		/// </summary>
 		/// <param name="o">The object encountered.</param>
-		public delegate void ObjectDelegate(object o);
+		public delegate void ObjectDelegate(object? o);
 
 		/// <summary>
 		/// Delegate for when an object's property is encountered.
@@ -476,6 +478,6 @@ namespace FrEee.Utility
 		/// <param name="o">The object possessing the property.</param>
 		/// <param name="val">The value of the property.</param>
 		/// <returns>true to recursively parse the property value, false to skip it</returns>
-		public delegate bool PropertyDelegate(string propertyName, object o, object val);
+		public delegate bool PropertyDelegate(string propertyName, object o, object? val);
 	}
 }

--- a/FrEee/Utility/PRNG.cs
+++ b/FrEee/Utility/PRNG.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using System;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -41,7 +43,7 @@ namespace FrEee.Utility
 			return r1.Seed == r2.Seed && r1.Iteration == r2.Iteration;
 		}
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
 			// TODO - upgrade equals to use "as" operator
 			if (obj is PRNG)

--- a/FrEee/Utility/Progress.cs
+++ b/FrEee/Utility/Progress.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Modding;
 using FrEee.Modding.Interfaces;
 using FrEee.Utility.Extensions;
@@ -7,7 +7,7 @@ using System;
 namespace FrEee.Utility
 {
 	public class GalaxyProgress<T> : Progress<GalaxyReference<T>, T>
-		where T: IReferrable
+		where T: class, IReferrable
 	{
 		public GalaxyProgress(T item, long value, long maximum, long incrementalProgressBeforeDelay = 0, double? delay = 0, long extraIncrementalProgressAfterDelay = 0)
 			: base(item, value, maximum, incrementalProgressBeforeDelay, delay, extraIncrementalProgressAfterDelay)

--- a/FrEee/Utility/Progress.cs
+++ b/FrEee/Utility/Progress.cs
@@ -3,6 +3,9 @@ using FrEee.Modding;
 using FrEee.Modding.Interfaces;
 using FrEee.Utility.Extensions;
 using System;
+using System.Diagnostics.CodeAnalysis;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -112,13 +115,12 @@ namespace FrEee.Utility
 		/// <summary>
 		/// The item being worked towards.
 		/// </summary>
-		public T Item { get { return item.Value; } set { item = value.Refer<TRef, T>(); } }
+		[MaybeNull]
+		public T Item { get => item.Value; set => item = value.Refer<TRef, T>(); }
 
-		private TRef item { get; set; }
+		[NotNull]
+		private TRef? item { get; set; }
 
-		public override string ToString()
-		{
-			return string.Format("{0}: {1}", Item, base.ToString());
-		}
+		public override string ToString() => $"{Item}: {base.ToString()}";
 	}
 }

--- a/FrEee/Utility/ProgressDisplayMode.cs
+++ b/FrEee/Utility/ProgressDisplayMode.cs
@@ -1,4 +1,6 @@
-﻿namespace FrEee.WinForms.DataGridView
+#nullable enable
+
+namespace FrEee.WinForms.DataGridView
 {
 	/// <summary>
 	/// Display modes for progress bars.

--- a/FrEee/Utility/RandomHelper.cs
+++ b/FrEee/Utility/RandomHelper.cs
@@ -1,5 +1,7 @@
 using System;
 
+#nullable enable
+
 namespace FrEee.Utility
 {
 	/// <summary>
@@ -7,10 +9,7 @@ namespace FrEee.Utility
 	/// </summary>
 	public static class RandomHelper
 	{
-		static RandomHelper()
-		{
-			PRNG = new PRNG((int)DateTime.Now.Ticks);
-		}
+		static RandomHelper() => PRNG = new PRNG((int)DateTime.Now.Ticks);
 
 		public static PRNG PRNG { get; private set; }
 
@@ -19,30 +18,21 @@ namespace FrEee.Utility
 		/// </summary>
 		/// <param name="upper">The upper bound.</param>
 		/// <returns></returns>
-		public static int Next(int upper, PRNG prng = null)
-		{
-			return (prng ?? PRNG).Next(upper);
-		}
+		public static int Next(int upper, PRNG? prng = null) => (prng ?? PRNG).Next(upper);
 
 		/// <summary>
 		/// Generates a random number >= 0 but less than the upper bound.
 		/// </summary>
 		/// <param name="upper">The upper bound.</param>
 		/// <returns></returns>
-		public static long Next(long upper, PRNG prng = null)
-		{
-			return (prng ?? PRNG).Next(upper);
-		}
+		public static long Next(long upper, PRNG? prng = null) => (prng ?? PRNG).Next(upper);
 
 		/// <summary>
 		/// Generates a random number >= 0 but less than the upper bound.
 		/// </summary>
 		/// <param name="upper">The upper bound.</param>
 		/// <returns></returns>
-		public static double Next(double upper, PRNG prng = null)
-		{
-			return (prng ?? PRNG).Next(upper);
-		}
+		public static double Next(double upper, PRNG? prng = null) => (prng ?? PRNG).Next(upper);
 
 		/// <summary>
 		/// Generates a random number within a range (inclusive).
@@ -50,10 +40,7 @@ namespace FrEee.Utility
 		/// <param name="min">The minimum.</param>
 		/// <param name="max">The maximum.</param>
 		/// <returns></returns>
-		public static int Range(int min, int max, PRNG prng = null)
-		{
-			return (prng ?? PRNG).Range(min, max);
-		}
+		public static int Range(int min, int max, PRNG? prng = null) => (prng ?? PRNG).Range(min, max);
 
 		/// <summary>
 		/// Generates a random number within a range (inclusive).
@@ -61,10 +48,7 @@ namespace FrEee.Utility
 		/// <param name="min">The minimum.</param>
 		/// <param name="max">The maximum.</param>
 		/// <returns></returns>
-		public static long Range(long min, long max, PRNG prng = null)
-		{
-			return (prng ?? PRNG).Range(min, max);
-		}
+		public static long Range(long min, long max, PRNG? prng = null) => (prng ?? PRNG).Range(min, max);
 
 		/// <summary>
 		/// Generates a random number within a range (inclusive).
@@ -72,29 +56,20 @@ namespace FrEee.Utility
 		/// <param name="min">The minimum.</param>
 		/// <param name="max">The maximum.</param>
 		/// <returns></returns>
-		public static double Range(double min, double max, PRNG prng = null)
-		{
-			return (prng ?? PRNG).Range(min, max);
-		}
+		public static double Range(double min, double max, PRNG? prng = null) => (prng ?? PRNG).Range(min, max);
 
 		/// <summary>
 		/// Determines if something happens based on a percentage chance.
 		/// </summary>
 		/// <param name="chance">The chance of something happening, between 0 and 100.</param>
 		/// <returns>Should something happen?</returns>
-		public static bool PercentageChance(double chance, PRNG prng = null)
-		{
-			return Range(0d, 100d, prng) < chance;
-		}
+		public static bool PercentageChance(double chance, PRNG? prng = null) => Range(0d, 100d, prng) < chance;
 
 		/// <summary>
 		/// Determines if something happens based on a per mille chance.
 		/// </summary>
 		/// <param name="chance">The chance of something happening, between 0 and 1000.</param>
 		/// <returns>Should something happen?</returns>
-		public static bool PerMilleChance(double chance, PRNG prng = null)
-		{
-			return Range(0d, 1000d, prng) < chance;
-		}
+		public static bool PerMilleChance(double chance, PRNG? prng = null) => Range(0d, 1000d, prng) < chance;
 	}
 }

--- a/FrEee/Utility/ReferenceKeyedDictionary.cs
+++ b/FrEee/Utility/ReferenceKeyedDictionary.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Space;
 using FrEee.Modding;
 using FrEee.Modding.Interfaces;
@@ -10,7 +10,7 @@ using System.Linq;
 namespace FrEee.Utility
 {
 	public class GalaxyReferenceKeyedDictionary<TKey, TValue> : ReferenceKeyedDictionary<long, GalaxyReference<TKey>, TKey, TValue>
-			where TKey : IReferrable
+			where TKey : class, IReferrable
 	{
 		private SafeDictionary<long, TKey> dict = new SafeDictionary<long, TKey>();
 

--- a/FrEee/Utility/ReferenceList.cs
+++ b/FrEee/Utility/ReferenceList.cs
@@ -5,6 +5,8 @@ using FrEee.Modding;
 using FrEee.Modding.Interfaces;
 using FrEee.Utility.Extensions;
 
+#nullable enable
+
 namespace FrEee.Utility
 {
 	public class GalaxyReferenceList<T> : ReferenceList<GalaxyReference<T>, T>
@@ -17,7 +19,7 @@ namespace FrEee.Utility
 	{
 	}
 
-	public class ReferenceList<TRef, T> : IList<T>, IReferenceEnumerable, IPromotable
+	public class ReferenceList<TRef, T> : IList<T?>, IReferenceEnumerable, IPromotable
 				where TRef : IReference<T>
 	{
 		public ReferenceList()
@@ -37,7 +39,7 @@ namespace FrEee.Utility
 
 		private IList<TRef> list { get; set; }
 
-		public T this[int index]
+		public T? this[int index]
 		{
 			get
 			{
@@ -49,7 +51,7 @@ namespace FrEee.Utility
 			}
 		}
 
-		public void Add(T item)
+		public void Add(T? item)
 		{
 			list.Add(MakeReference(item));
 		}
@@ -59,17 +61,17 @@ namespace FrEee.Utility
 			list.Clear();
 		}
 
-		public bool Contains(T item)
+		public bool Contains(T? item)
 		{
 			return list.Any(r => r.Value.Equals(item));
 		}
 
-		public void CopyTo(T[] array, int arrayIndex)
+		public void CopyTo(T?[] array, int arrayIndex)
 		{
 			list.Select(x => x.Value).ToList().CopyTo(array, arrayIndex);
 		}
 
-		public IEnumerator<T> GetEnumerator()
+		public IEnumerator<T?> GetEnumerator()
 		{
 			return list.Select(x => x.Value).GetEnumerator();
 		}
@@ -79,19 +81,19 @@ namespace FrEee.Utility
 			return GetEnumerator();
 		}
 
-		public int IndexOf(T item)
+		public int IndexOf(T? item)
 		{
 			if (!list.Any(r => r.Value.Equals(item)))
 				return -1;
 			return list.Select((x, i) => new { Item = x, Index = i }).First(x => x.Item.Value.Equals(item)).Index;
 		}
 
-		public void Insert(int index, T item)
+		public void Insert(int index, T? item)
 		{
 			list.Insert(index, MakeReference(item));
 		}
 
-		public bool Remove(T item)
+		public bool Remove(T? item)
 		{
 			var i = IndexOf(item);
 			if (i >= 0)
@@ -123,7 +125,7 @@ namespace FrEee.Utility
 			}
 		}
 
-		private static TRef MakeReference(T item)
+		private static TRef MakeReference(T? item)
 		{
 			return (TRef)typeof(TRef).Instantiate(item);
 		}

--- a/FrEee/Utility/ReferenceList.cs
+++ b/FrEee/Utility/ReferenceList.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using FrEee.Game.Interfaces;
 using FrEee.Modding;
@@ -8,7 +8,7 @@ using FrEee.Utility.Extensions;
 namespace FrEee.Utility
 {
 	public class GalaxyReferenceList<T> : ReferenceList<GalaxyReference<T>, T>
-		where T : IReferrable
+		where T : class, IReferrable
 	{
 	}
 

--- a/FrEee/Utility/ReferenceSet.cs
+++ b/FrEee/Utility/ReferenceSet.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Modding;
 using FrEee.Modding.Interfaces;
 using FrEee.Utility.Extensions;
@@ -10,7 +10,7 @@ namespace FrEee.Utility
 {
 	[Serializable]
 	public class GalaxyReferenceSet<T> : ReferenceSet<GalaxyReference<T>, T>
-		where T : IReferrable
+		where T : class, IReferrable
 	{
 		public GalaxyReferenceSet()
 			: base()

--- a/FrEee/Utility/ReferenceSet.cs
+++ b/FrEee/Utility/ReferenceSet.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Utility
 {
 	[Serializable]
@@ -72,7 +74,7 @@ namespace FrEee.Utility
 
         private bool isSetDirty = true;
 
-        private ISet<T> _Set;
+        private ISet<T> _Set = new HashSet<T>();
 
 		private ISet<T> Set
         {
@@ -179,7 +181,7 @@ namespace FrEee.Utility
 				return set.Remove(MakeReference(item));
 		}
 
-		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable> done = null)
+		public void ReplaceClientIDs(IDictionary<long, long> idmap, ISet<IPromotable>? done = null)
 		{
 			if (done == null)
 				done = new HashSet<IPromotable>();

--- a/FrEee/Utility/Resource.cs
+++ b/FrEee/Utility/Resource.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Utility.Extensions;
 using System;
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -33,12 +35,12 @@ namespace FrEee.Utility
 		/// All resources in the game.
 		/// TODO - moddable resources?
 		/// </summary>
-		public static IEnumerable<Resource> All { get { return all; } }
+		public static IEnumerable<Resource> All => all;
 
 		/// <summary>
 		/// The aptitude (if any) which affects the generation rate of this resource.
 		/// </summary>
-		public Aptitude Aptitude { get; set; }
+		public Aptitude? Aptitude { get; set; }
 
 		/// <summary>
 		/// A color used to represent the resource.
@@ -58,10 +60,7 @@ namespace FrEee.Utility
 		/// <summary>
 		/// An icon used to represent this resource.
 		/// </summary>
-		public Image Icon
-		{
-			get { return Pictures.GetIcon(this); }
-		}
+		public Image Icon => Pictures.GetIcon(this);
 
 		public Image Icon32 => Icon.Resize(32);
 
@@ -86,11 +85,7 @@ namespace FrEee.Utility
 		/// <summary>
 		/// The name of the resource.
 		/// </summary>
-		public string Name
-		{
-			get;
-			set;
-		}
+		public string Name { get; set; }
 
 		/// <summary>
 		/// The name of the picture to use for this resource.
@@ -100,18 +95,9 @@ namespace FrEee.Utility
 		/// <summary>
 		/// Just use the icon image.
 		/// </summary>
-		public Image Portrait
-		{
-			get { return Icon; }
-		}
+		public Image Portrait => Icon;
 
-		public IEnumerable<string> PortraitPaths
-		{
-			get
-			{
-				return IconPaths;
-			}
-		}
+		public IEnumerable<string> PortraitPaths => IconPaths;
 
 		public static readonly Resource Intelligence = new Resource
 		{
@@ -187,15 +173,9 @@ namespace FrEee.Utility
 
 		private static IEnumerable<Resource> all;
 
-		public static Resource Find(string name)
-		{
-			return All.SingleOrDefault(r => r.Name == name);
-		}
+		public static Resource Find(string name) => All.SingleOrDefault(r => r.Name == name);
 
-		public static bool operator !=(Resource r1, Resource r2)
-		{
-			return !(r1 == r2);
-		}
+		public static bool operator !=(Resource r1, Resource r2) => !(r1 == r2);
 
 		public static ResourceQuantity operator *(int quantity, Resource resource)
 		{
@@ -204,10 +184,7 @@ namespace FrEee.Utility
 			return q;
 		}
 
-		public static ResourceQuantity operator *(Resource r, int quantity)
-		{
-			return quantity * r;
-		}
+		public static ResourceQuantity operator *(Resource r, int quantity) => quantity * r;
 
 		public static bool operator ==(Resource r1, Resource r2)
 		{
@@ -218,7 +195,7 @@ namespace FrEee.Utility
 			return r1.Name == r2.Name && r1.Color == r2.Color && r1.IsGlobal == r2.IsGlobal && r1.IsLocal == r2.IsLocal && r1.PictureName == r2.PictureName;
 		}
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
 			var r = obj as Resource;
 			if (ReferenceEquals(r, null))
@@ -226,14 +203,8 @@ namespace FrEee.Utility
 			return this == r;
 		}
 
-		public override int GetHashCode()
-		{
-			return Name.GetSafeHashCode();
-		}
+		public override int GetHashCode() => Name.GetSafeHashCode();
 
-		public override string ToString()
-		{
-			return Name;
-		}
+		public override string ToString() => Name;
 	}
 }

--- a/FrEee/Utility/ResourceProgress.cs
+++ b/FrEee/Utility/ResourceProgress.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -26,14 +28,8 @@ namespace FrEee.Utility
 				yield return new KeyValuePair<Resource, Progress>(r, new Progress(Value[r], Maximum[r], IncrementalProgress[r]));
 		}
 
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return GetEnumerator();
-		}
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-		public override string ToString()
-		{
-			return string.Format("{0} / {1} ({2:+#;-#;0} per turn", Value, Maximum, IncrementalProgress);
-		}
+		public override string ToString() => string.Format("{0} / {1} ({2:+#;-#;0} per turn", Value, Maximum, IncrementalProgress);
 	}
 }

--- a/FrEee/Utility/ResourceQuantity.cs
+++ b/FrEee/Utility/ResourceQuantity.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Utility
 {
 	/// <summary>
@@ -14,7 +16,7 @@ namespace FrEee.Utility
 		/// <summary>
 		/// Is this quantity all zeroes?
 		/// </summary>
-		public bool IsEmpty { get { return this.All(kvp => kvp.Value == 0); } }
+		public bool IsEmpty => this.All(kvp => kvp.Value == 0);
 
 		public ResourceQuantity()
 		{
@@ -70,7 +72,7 @@ namespace FrEee.Utility
 			return result;
 		}
 
-		public static bool operator !=(ResourceQuantity r1, ResourceQuantity r2)
+		public static bool operator !=(ResourceQuantity? r1, ResourceQuantity? r2)
 		{
 			return !(r1 == r2);
 		}
@@ -124,13 +126,13 @@ namespace FrEee.Utility
 			return true;
 		}
 
-		public static bool operator ==(ResourceQuantity r1, ResourceQuantity r2)
+		public static bool operator ==(ResourceQuantity? r1, ResourceQuantity? r2)
 		{
 			if (r1.IsNull() && r2.IsNull())
 				return true;
 			if (r1.IsNull() || r2.IsNull())
 				return false;
-			foreach (var key in r1.Keys.Union(r2.Keys))
+			foreach (var key in r1!.Keys.Union(r2!.Keys))
 			{
 				if (r1[key] != r2[key])
 					return false;
@@ -199,19 +201,19 @@ namespace FrEee.Utility
 			this[key] += value;
 		}
 
-		public int CompareTo(ResourceQuantity other)
+		public int CompareTo(ResourceQuantity? other)
 		{
 			return this.Sum(kvp => kvp.Value).CompareTo(other.Sum(kvp => kvp.Value));
 		}
 
-		public int CompareTo(object obj)
+		public int CompareTo(object? obj)
 		{
 			if (obj is ResourceQuantity)
 				return CompareTo((ResourceQuantity)obj);
-			return this.Sum(kvp => kvp.Value).CompareTo(obj.ToString().ToInt());
+			return this.Sum(kvp => kvp.Value).CompareTo(obj?.ToString().ToInt());
 		}
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
 			if (obj is ResourceQuantity rq)
 				return this == rq;

--- a/FrEee/Utility/SafeDictionary.cs
+++ b/FrEee/Utility/SafeDictionary.cs
@@ -4,6 +4,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace FrEee.Utility
 {
 	/// <summary>
@@ -12,7 +14,7 @@ namespace FrEee.Utility
 	/// <typeparam name="TKey"></typeparam>
 	/// <typeparam name="TValue"></typeparam>
 	[Serializable]
-	public class SafeDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+	public class SafeDictionary<TKey, TValue> : IDictionary<TKey, TValue?> where TKey : notnull
 	{
 		public SafeDictionary()
 			: this(false)
@@ -25,7 +27,7 @@ namespace FrEee.Utility
 			AutoInit = autoInit;
 		}
 
-		public SafeDictionary(IDictionary<TKey, TValue> tocopy, bool autoInit = false)
+		public SafeDictionary(IDictionary<TKey, TValue?> tocopy, bool autoInit = false)
 			: this(autoInit)
 		{
 			foreach (var kvp in tocopy)
@@ -40,7 +42,7 @@ namespace FrEee.Utility
 		/// <summary>
 		/// For initializing newly created values.
 		/// </summary>
-		public object[] AutoInitArgs { get; set; }
+		public object[]? AutoInitArgs { get; set; }
 
 		public int Count
 		{
@@ -70,24 +72,24 @@ namespace FrEee.Utility
 			}
 		}
 
-		public ICollection<TValue> Values
+		public ICollection<TValue?> Values
 		{
 			get
 			{
 				if (dict == null)
-					return new List<TValue>();
+					return new List<TValue?>();
 				return dict.Values;
 			}
 		}
 
-		private ConcurrentDictionary<TKey, TValue> dict;
+		private ConcurrentDictionary<TKey, TValue?> dict;
 
-		public TValue this[TKey key]
+		public TValue? this[TKey key]
 		{
 			get
 			{
 				if (dict == null)
-					return default(TValue);
+					return default;
 				TValue val;
 				if (dict.TryGetValue(key, out val))
 					return val;
@@ -104,11 +106,11 @@ namespace FrEee.Utility
 						catch
 						{
 							// can't instantiate the object
-							return default(TValue);
+							return default;
 						}
 					}
 					else
-						return default(TValue);
+						return default;
 				}
 			}
 			set
@@ -118,12 +120,12 @@ namespace FrEee.Utility
 			}
 		}
 
-		public virtual void Add(TKey key, TValue value)
+		public virtual void Add(TKey key, TValue? value)
 		{
 			this[key] = value;
 		}
 
-		public virtual void Add(KeyValuePair<TKey, TValue> item)
+		public virtual void Add(KeyValuePair<TKey, TValue?> item)
 		{
 			this[item.Key] = item.Value;
 		}
@@ -134,7 +136,7 @@ namespace FrEee.Utility
 				dict.Clear();
 		}
 
-		public bool Contains(KeyValuePair<TKey, TValue> item)
+		public bool Contains(KeyValuePair<TKey, TValue?> item)
 		{
 			if (dict == null)
 				return false;
@@ -152,16 +154,16 @@ namespace FrEee.Utility
 			return dict.ContainsKey(key);
 		}
 
-		public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+		public void CopyTo(KeyValuePair<TKey, TValue?>[] array, int arrayIndex)
 		{
 			if (dict != null)
-				((IDictionary<TKey, TValue>)dict).CopyTo(array, arrayIndex);
+				((IDictionary<TKey, TValue?>)dict).CopyTo(array, arrayIndex);
 		}
 
-		public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+		public IEnumerator<KeyValuePair<TKey, TValue?>> GetEnumerator()
 		{
 			if (dict == null)
-				return Enumerable.Empty<KeyValuePair<TKey, TValue>>().GetEnumerator();
+				return Enumerable.Empty<KeyValuePair<TKey, TValue?>>().GetEnumerator();
 			return dict.GetEnumerator();
 		}
 
@@ -177,17 +179,17 @@ namespace FrEee.Utility
 			return dict.TryRemove(key, out _);
 		}
 
-		public bool Remove(KeyValuePair<TKey, TValue> item)
+		public bool Remove(KeyValuePair<TKey, TValue?> item)
 		{
 			if (dict == null)
 				return false;
-			return ((IDictionary<TKey, TValue>)dict).Remove(item);
+			return ((IDictionary<TKey, TValue?>)dict).Remove(item);
 		}
 
-		public bool TryGetValue(TKey key, out TValue value)
+		public bool TryGetValue(TKey key, out TValue? value)
 		{
 			if (dict == null)
-				value = default(TValue);
+				value = default;
 			else
 				value = this[key];
 			return true;
@@ -199,7 +201,7 @@ namespace FrEee.Utility
 		private void InitDict()
 		{
 			if (dict == null)
-				dict = new ConcurrentDictionary<TKey, TValue>();
+				dict = new ConcurrentDictionary<TKey, TValue?>();
 		}
 	}
 }

--- a/FrEee/Utility/SafeType.cs
+++ b/FrEee/Utility/SafeType.cs
@@ -1,9 +1,11 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+
+#nullable enable
 
 namespace FrEee.Utility
 {

--- a/FrEee/Utility/SequenceEqualityComparer.cs
+++ b/FrEee/Utility/SequenceEqualityComparer.cs
@@ -1,11 +1,13 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
 	internal class SequenceEqualityComparer<T> : IEqualityComparer<IEnumerable<T>>
 	{
-		public bool Equals(IEnumerable<T> x, IEnumerable<T> y)
+		public bool Equals(IEnumerable<T>? x, IEnumerable<T>? y)
 		{
 			if (x.Count() != y.Count())
 				return false;

--- a/FrEee/Utility/Serializer.cs
+++ b/FrEee/Utility/Serializer.cs
@@ -1,8 +1,10 @@
-using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Runtime.Serialization;
-using System.Text;
+
+using Newtonsoft.Json;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -15,7 +17,7 @@ namespace FrEee.Utility
 
 		public static bool IsDeserializing { get; private set; }
 
-		public static T Deserialize<T>(string s)
+		public static T? Deserialize<T>(string s)
 		{
 			IsDeserializing = true;
 			T t;
@@ -31,12 +33,12 @@ namespace FrEee.Utility
 			return t;
 		}
 
-		public static T Deserialize<T>(Stream str)
+		public static T? Deserialize<T>(Stream str)
 		{
-			return (T)Deserialize(str);
+			return (T?)Deserialize(str);
 		}
 
-		public static object Deserialize(Stream str)
+		public static object? Deserialize(Stream str)
 		{
 			try
 			{
@@ -64,12 +66,12 @@ namespace FrEee.Utility
 			}
 		}
 
-		public static T DeserializeFromString<T>(string s)
+		public static T? DeserializeFromString<T>(string s)
 		{
-			return (T)DeserializeFromString(s);
+			return (T?)DeserializeFromString(s);
 		}
 
-		public static object DeserializeFromString(string s)
+		public static object? DeserializeFromString(string s)
 		{
 			if (EnableJsonSerializer)
 			{

--- a/FrEee/Utility/SimpleDataObject.cs
+++ b/FrEee/Utility/SimpleDataObject.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using Newtonsoft.Json;
 using System;
 using static FrEee.Utility.Extensions.CommonExtensions;
@@ -10,16 +10,13 @@ namespace FrEee.Utility
 		ObjectGraphContext Context { get; set; }
 		int ID { get; }
 
-		SafeDictionary<string, IData> SimpleData
-		{
-			get; set;
-		}
+		SafeDictionary<string, IData> SimpleData { get; set; }
 
 		object Value { get; }
 
-		void InitializeData(ObjectGraphContext ctx = null);
+		void InitializeData(ObjectGraphContext? ctx = null);
 
-		void InitializeValue(ObjectGraphContext ctx = null);
+		void InitializeValue(ObjectGraphContext? ctx = null);
 	}
 
 	/// <summary>
@@ -33,7 +30,7 @@ namespace FrEee.Utility
 			Type = typeof(object);
 		}
 
-		public SimpleDataObject(object o, ObjectGraphContext ctx = null)
+		public SimpleDataObject(object o, ObjectGraphContext? ctx = null)
 		{
 			Context = ctx ?? new ObjectGraphContext();
 			if (o != null)
@@ -51,7 +48,7 @@ namespace FrEee.Utility
 			}
 		}
 
-		public SimpleDataObject(SafeDictionary<string, IData> simpleData, ObjectGraphContext ctx = null)
+		public SimpleDataObject(SafeDictionary<string, IData> simpleData, ObjectGraphContext? ctx = null)
 		{
 			SimpleData = simpleData;
 			Context = ctx ?? new ObjectGraphContext();
@@ -109,10 +106,7 @@ namespace FrEee.Utility
 			}
 		}
 
-		public SafeDictionary<string, IData> SimpleData
-		{
-			get; set;
-		}
+		public SafeDictionary<string, IData> SimpleData { get; set; }
 
 		public SafeType Type { get; private set; }
 
@@ -141,15 +135,12 @@ namespace FrEee.Utility
 			}
 		}
 
-		object ISimpleDataObject.Value
-		{
-			get { return Value; }
-		}
+		object ISimpleDataObject.Value => Value;
 
 		[NonSerialized]
 		private object value;
 
-		public static ISimpleDataObject Create(object o, ObjectGraphContext ctx = null)
+		public static ISimpleDataObject Create(object o, ObjectGraphContext? ctx = null)
 		{
 			if (o == null)
 				return null;
@@ -157,7 +148,7 @@ namespace FrEee.Utility
 			return new SimpleDataObject(o, ctx);
 		}
 
-		public static ISimpleDataObject Load(SafeDictionary<string, IData> simpleData, ObjectGraphContext ctx = null)
+		public static ISimpleDataObject Load(SafeDictionary<string, IData> simpleData, ObjectGraphContext? ctx = null)
 		{
 			if (simpleData == null)
 				return null;
@@ -165,19 +156,19 @@ namespace FrEee.Utility
 			return new SimpleDataObject(simpleData, ctx);
 		}
 
-		public void InitializeData(ObjectGraphContext ctx = null)
+		public void InitializeData(ObjectGraphContext? ctx = null)
 		{
 			Data = Value.GetData(ctx ?? Context);
 		}
 
-		public void InitializeValue(ObjectGraphContext ctx = null)
+		public void InitializeValue(ObjectGraphContext? ctx = null)
 		{
 			if (Context.GetID(Value) == null)
 				Context.Add(Value);
 			Value.SetData(Data, ctx ?? Context);
 		}
 
-		public T Reconstitute<T>(ObjectGraphContext ctx = null)
+		public T Reconstitute<T>(ObjectGraphContext? ctx = null)
 		{
 			var result = (T)typeof(T).Instantiate();
 			result.SetData(Data, ctx ?? new ObjectGraphContext());

--- a/FrEee/Utility/SimpleDataObject.cs
+++ b/FrEee/Utility/SimpleDataObject.cs
@@ -14,9 +14,9 @@ namespace FrEee.Utility
 
 		object Value { get; }
 
-		void InitializeData(ObjectGraphContext? ctx = null);
+		void InitializeData(ObjectGraphContext ctx = null);
 
-		void InitializeValue(ObjectGraphContext? ctx = null);
+		void InitializeValue(ObjectGraphContext ctx = null);
 	}
 
 	/// <summary>
@@ -30,7 +30,7 @@ namespace FrEee.Utility
 			Type = typeof(object);
 		}
 
-		public SimpleDataObject(object o, ObjectGraphContext? ctx = null)
+		public SimpleDataObject(object o, ObjectGraphContext ctx = null)
 		{
 			Context = ctx ?? new ObjectGraphContext();
 			if (o != null)
@@ -48,7 +48,7 @@ namespace FrEee.Utility
 			}
 		}
 
-		public SimpleDataObject(SafeDictionary<string, IData> simpleData, ObjectGraphContext? ctx = null)
+		public SimpleDataObject(SafeDictionary<string, IData> simpleData, ObjectGraphContext ctx = null)
 		{
 			SimpleData = simpleData;
 			Context = ctx ?? new ObjectGraphContext();
@@ -140,7 +140,7 @@ namespace FrEee.Utility
 		[NonSerialized]
 		private object value;
 
-		public static ISimpleDataObject Create(object o, ObjectGraphContext? ctx = null)
+		public static ISimpleDataObject Create(object o, ObjectGraphContext ctx = null)
 		{
 			if (o == null)
 				return null;
@@ -148,7 +148,7 @@ namespace FrEee.Utility
 			return new SimpleDataObject(o, ctx);
 		}
 
-		public static ISimpleDataObject Load(SafeDictionary<string, IData> simpleData, ObjectGraphContext? ctx = null)
+		public static ISimpleDataObject Load(SafeDictionary<string, IData> simpleData, ObjectGraphContext ctx = null)
 		{
 			if (simpleData == null)
 				return null;
@@ -156,19 +156,19 @@ namespace FrEee.Utility
 			return new SimpleDataObject(simpleData, ctx);
 		}
 
-		public void InitializeData(ObjectGraphContext? ctx = null)
+		public void InitializeData(ObjectGraphContext ctx = null)
 		{
 			Data = Value.GetData(ctx ?? Context);
 		}
 
-		public void InitializeValue(ObjectGraphContext? ctx = null)
+		public void InitializeValue(ObjectGraphContext ctx = null)
 		{
 			if (Context.GetID(Value) == null)
 				Context.Add(Value);
 			Value.SetData(Data, ctx ?? Context);
 		}
 
-		public T Reconstitute<T>(ObjectGraphContext? ctx = null)
+		public T Reconstitute<T>(ObjectGraphContext ctx = null)
 		{
 			var result = (T)typeof(T).Instantiate();
 			result.SetData(Data, ctx ?? new ObjectGraphContext());

--- a/FrEee/Utility/SimpleDataObject.cs
+++ b/FrEee/Utility/SimpleDataObject.cs
@@ -3,6 +3,8 @@ using Newtonsoft.Json;
 using System;
 using static FrEee.Utility.Extensions.CommonExtensions;
 
+#nullable enable
+
 namespace FrEee.Utility
 {
 	public interface ISimpleDataObject : IDataObject
@@ -14,9 +16,9 @@ namespace FrEee.Utility
 
 		object Value { get; }
 
-		void InitializeData(ObjectGraphContext ctx = null);
+		void InitializeData(ObjectGraphContext? ctx = null);
 
-		void InitializeValue(ObjectGraphContext ctx = null);
+		void InitializeValue(ObjectGraphContext? ctx = null);
 	}
 
 	/// <summary>
@@ -30,7 +32,7 @@ namespace FrEee.Utility
 			Type = typeof(object);
 		}
 
-		public SimpleDataObject(object o, ObjectGraphContext ctx = null)
+		public SimpleDataObject(object o, ObjectGraphContext? ctx = null)
 		{
 			Context = ctx ?? new ObjectGraphContext();
 			if (o != null)
@@ -48,7 +50,7 @@ namespace FrEee.Utility
 			}
 		}
 
-		public SimpleDataObject(SafeDictionary<string, IData> simpleData, ObjectGraphContext ctx = null)
+		public SimpleDataObject(SafeDictionary<string, IData> simpleData, ObjectGraphContext? ctx = null)
 		{
 			SimpleData = simpleData;
 			Context = ctx ?? new ObjectGraphContext();
@@ -106,9 +108,9 @@ namespace FrEee.Utility
 			}
 		}
 
-		public SafeDictionary<string, IData> SimpleData { get; set; }
+		public SafeDictionary<string, IData>? SimpleData { get; set; }
 
-		public SafeType Type { get; private set; }
+		public SafeType? Type { get; private set; }
 
 		[JsonIgnore]
 		public object Value
@@ -138,9 +140,9 @@ namespace FrEee.Utility
 		object ISimpleDataObject.Value => Value;
 
 		[NonSerialized]
-		private object value;
+		private object? value;
 
-		public static ISimpleDataObject Create(object o, ObjectGraphContext ctx = null)
+		public static ISimpleDataObject? Create(object o, ObjectGraphContext? ctx = null)
 		{
 			if (o == null)
 				return null;
@@ -148,7 +150,7 @@ namespace FrEee.Utility
 			return new SimpleDataObject(o, ctx);
 		}
 
-		public static ISimpleDataObject Load(SafeDictionary<string, IData> simpleData, ObjectGraphContext ctx = null)
+		public static ISimpleDataObject? Load(SafeDictionary<string, IData> simpleData, ObjectGraphContext? ctx = null)
 		{
 			if (simpleData == null)
 				return null;
@@ -156,19 +158,19 @@ namespace FrEee.Utility
 			return new SimpleDataObject(simpleData, ctx);
 		}
 
-		public void InitializeData(ObjectGraphContext ctx = null)
+		public void InitializeData(ObjectGraphContext? ctx = null)
 		{
 			Data = Value.GetData(ctx ?? Context);
 		}
 
-		public void InitializeValue(ObjectGraphContext ctx = null)
+		public void InitializeValue(ObjectGraphContext? ctx = null)
 		{
 			if (Context.GetID(Value) == null)
 				Context.Add(Value);
 			Value.SetData(Data, ctx ?? Context);
 		}
 
-		public T Reconstitute<T>(ObjectGraphContext ctx = null)
+		public T Reconstitute<T>(ObjectGraphContext? ctx = null)
 		{
 			var result = (T)typeof(T).Instantiate();
 			result.SetData(Data, ctx ?? new ObjectGraphContext());

--- a/FrEee/Utility/Status.cs
+++ b/FrEee/Utility/Status.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -10,7 +12,7 @@ namespace FrEee.Utility
 		/// <summary>
 		/// Any exception that may have occurred.
 		/// </summary>
-		public Exception Exception
+		public Exception? Exception
 		{
 			get { return exception; }
 			set
@@ -24,7 +26,7 @@ namespace FrEee.Utility
 		/// <summary>
 		/// Message indicating current sub-operation.
 		/// </summary>
-		public string Message
+		public string? Message
 		{
 			get { return message; }
 			set
@@ -51,11 +53,11 @@ namespace FrEee.Utility
 			}
 		}
 
-		private Exception exception;
-		private string message;
+		private Exception? exception;
+		private string? message;
 		private double progress;
 
-		public event ChangedDelegate Changed;
+		public event ChangedDelegate? Changed;
 
 		public delegate void ChangedDelegate();
 	}

--- a/FrEee/Utility/Stringifiers/DoubleLiteralFormulaStringifier.cs
+++ b/FrEee/Utility/Stringifiers/DoubleLiteralFormulaStringifier.cs
@@ -1,11 +1,8 @@
-﻿using FrEee.Modding;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using FrEee.Modding;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Stringifiers/IStringifier.cs
+++ b/FrEee/Utility/Stringifiers/IStringifier.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Stringifiers/IntLiteralFormulaStringifier.cs
+++ b/FrEee/Utility/Stringifiers/IntLiteralFormulaStringifier.cs
@@ -1,11 +1,8 @@
-﻿using FrEee.Modding;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using FrEee.Modding;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Stringifiers/PointStringifier.cs
+++ b/FrEee/Utility/Stringifiers/PointStringifier.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Stringifiers/PopulationModifierStringifier.cs
+++ b/FrEee/Utility/Stringifiers/PopulationModifierStringifier.cs
@@ -1,11 +1,9 @@
-﻿using FrEee.Modding;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using FrEee.Modding;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Stringifiers/ResourceQuantityStringifier.cs
+++ b/FrEee/Utility/Stringifiers/ResourceQuantityStringifier.cs
@@ -1,11 +1,6 @@
-﻿using FrEee.Modding;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Stringifiers/SizeStringifier.cs
+++ b/FrEee/Utility/Stringifiers/SizeStringifier.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Stringifiers/StringLiteralFormulaStringifier.cs
+++ b/FrEee/Utility/Stringifiers/StringLiteralFormulaStringifier.cs
@@ -1,11 +1,8 @@
-﻿using FrEee.Modding;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using FrEee.Modding;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Stringifiers/Stringifier.cs
+++ b/FrEee/Utility/Stringifiers/Stringifier.cs
@@ -1,9 +1,6 @@
-﻿using FrEee.Game.Objects.Space;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Stringifiers/StringifierLibrary.cs
+++ b/FrEee/Utility/Stringifiers/StringifierLibrary.cs
@@ -1,10 +1,8 @@
-﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+#nullable enable
 
 namespace FrEee.Utility.Stringifiers
 {

--- a/FrEee/Utility/Vector2.cs
+++ b/FrEee/Utility/Vector2.cs
@@ -1,5 +1,7 @@
-﻿using FrEee.Utility.Extensions;
+using FrEee.Utility.Extensions;
 using System;
+
+#nullable enable
 
 namespace FrEee.Utility
 {
@@ -7,7 +9,7 @@ namespace FrEee.Utility
 	///  A generic two dimensional vector.
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
-	public class Vector2<T> : IEquatable<Vector2<T>>
+	public class Vector2<T> : IEquatable<Vector2<T>> where T : struct
 	{
 		public Vector2()
 			: this(default(T), default(T))
@@ -28,8 +30,10 @@ namespace FrEee.Utility
 		public T X { get; set; }
 		public T Y { get; set; }
 
-		public bool Equals(Vector2<T> other)
+		public bool Equals(Vector2<T>? other)
 		{
+			if (other is null)
+				return false;
 			return X.SafeEquals(other.X) && Y.SafeEquals(other.Y);
 		}
 	}


### PR DESCRIPTION
This pull request contains first few batches of files with null-checking enabled (it got much easier once I've discovered that it can be enabled on the per-file basis).

The number of changes is still really, really big, so I've decided to set up a draft pull request with the first batch once I've encountered first major problem - the generics require a bit more complex handling with regards to nulls now, and the next set of files to convert are various commands, with inherit from `Command<T>`.