### PR TITLE
174 - Error: no savegame folder when clicking resume game

### DIFF
--- a/FrEee.WinForms/Forms/MainMenuForm.cs
+++ b/FrEee.WinForms/Forms/MainMenuForm.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Objects.Space;
+using FrEee.Game.Objects.Space;
 using FrEee.Game.Objects.Vehicles;
 using FrEee.Game.Setup;
 using FrEee.Modding;
@@ -233,15 +233,28 @@ namespace FrEee.WinForms.Forms
 
 		private void btnResume_Click(object sender, EventArgs e)
 		{
-			var mostRecent = Directory.GetFiles(Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Savegame"))
-				.Select(filePath => new KeyValuePair<string, DateTime>(filePath, File.GetLastWriteTime(filePath)))
-				.OrderByDescending(kvp => kvp.Value)
-				.Where(kvp => Regex.Match(kvp.Key, @"_\d+_\d+.gam$").Success)
-				.ToList();
-			if (mostRecent.Any())
-				LoadGalaxyFromFile(mostRecent.First().Key, true);
+			string savegameDir = Program.GetPath(FrEeeConstants.SaveGameDirectory);
+			string noSavesMessage = "No games to resume; please create a new game.";
+
+			if (Directory.Exists(savegameDir))
+			{
+				// Savegame folder exists, find recent saves
+				var mostRecent = Directory.GetFiles(savegameDir)
+					   .Select(filePath => new KeyValuePair<string, DateTime>(filePath, File.GetLastWriteTime(filePath)))
+					   .OrderByDescending(kvp => kvp.Value)
+					   .Where(kvp => Regex.Match(kvp.Key, @"_\d+_\d+.gam$").Success)
+					   .ToList();
+				if (mostRecent.Any())
+					LoadGalaxyFromFile(mostRecent.First().Key, true);
+				else
+					MessageBox.Show(noSavesMessage);
+			}
 			else
-				MessageBox.Show("No games to resume; please create a new game.");
+			{
+				// Savegame folder doesn't exist, create it
+				Directory.CreateDirectory(savegameDir);
+				MessageBox.Show(noSavesMessage);
+			}
 		}
 
 		private void btnScenario_Click(object sender, EventArgs e)

--- a/FrEee.WinForms/Program.cs
+++ b/FrEee.WinForms/Program.cs
@@ -1,4 +1,4 @@
-﻿using FrEee.Game.Interfaces;
+using FrEee.Game.Interfaces;
 using FrEee.Game.Objects.Civilization;
 using FrEee.Game.Objects.Space;
 using FrEee.Game.Objects.Vehicles;
@@ -309,5 +309,25 @@ FrEee --restart gamename_turnnumber_playernumber.gam: play a turn, restarting fr
 				return 3;
 			}
 		}
+
+		/// <summary>
+		/// The path of the executable for the game.
+		/// </summary>
+		public static string ExecutablePath
+			=> Assembly.GetEntryAssembly()?.Location ?? throw new NotSupportedException("Can't retrieve executable path from unmanaged code.");
+
+		/// <summary>
+		/// The root directory of the game.
+		/// </summary>
+		public static string RootDirectory
+			=> Path.GetDirectoryName(ExecutablePath) ?? throw new ArgumentNullException(nameof(ExecutablePath));
+
+		/// <summary>
+		/// Gets a path starting with the root directory of the game.
+		/// </summary>
+		/// <param name="dirs">Directories in order of hierarchy, e.g. to retrieve the path of Pictures/Races/Neutral001 you would pass in "Pictures", then "Races", then "Neutral001".</param>
+		/// <returns></returns>
+		public static string GetPath(params string[] dirs)
+			=> Path.Combine(new string[] { RootDirectory }.Concat(dirs).ToArray());
 	}
 }


### PR DESCRIPTION
Now the folder is just created and the user is told it's empty instead of throwing an error.