### PR TITLE
220 starting homeworld option

### DIFF
--- a/FrEee.WinForms/Forms/GameSetupForm.cs
+++ b/FrEee.WinForms/Forms/GameSetupForm.cs
@@ -38,8 +38,17 @@ namespace FrEee.WinForms.Forms
 			galaxyTemplateBindingSource.DataSource = Mod.Current.GalaxyTemplates;
 			warpPointPlacementStrategyBindingSource.DataSource = WarpPointPlacementStrategy.All;
 			lstTechs.Items.AddRange(Mod.Current.Technologies.Where(t => t.CanBeRemoved).ToArray());
-			foreach (var item in Mod.Current.StellarObjectSizes.Where(q => q.StellarObjectType == "Planet"))
+			// only allow homeworlds to be planet sizes that can exist as any planet surface or atmosphere,
+			// to avoid errors placing empires on incompatible planets
+			var surfaces = Mod.Current.StellarObjectTemplates.OfType<Planet>().Select(p => p.Surface).Distinct();
+			var atmospheres = Mod.Current.StellarObjectTemplates.OfType<Planet>().Select(p => p.Atmosphere).Distinct();
+			foreach (var item in Mod.Current.StellarObjectSizes.Where(q =>
+				q.StellarObjectType == "Planet"
+				&& surfaces.All(w => Mod.Current.StellarObjectTemplates.OfType<Planet>().Any(e => e.Size == q && e.Surface == w))
+				&& atmospheres.All(w => Mod.Current.StellarObjectTemplates.OfType<Planet>().Any(e => e.Size == q && e.Atmosphere == w))))
+			{
 				ddlHomeworldSize.Items.Add(item);
+			}
 			// TODO - set step-amount for racial points spinbox to the greatest common factor of the mod's racial trait costs? or maybe based on aptitudes too?
 			ddlAllowedTrades.DataSource = Enum.GetValues(typeof(AllowedTrades)).Cast<AllowedTrades>().Select(e => new { Name = e.ToSpacedString(), Value = e }).ToList();
 			ddlAllowedTrades.SelectedValue = AllowedTrades.All;

--- a/FrEee/Game/Setup/GameSetup.cs
+++ b/FrEee/Game/Setup/GameSetup.cs
@@ -437,8 +437,8 @@ namespace FrEee.Game.Setup
 			var hw = Mod.Current.StellarObjectTemplates.OfType<Planet>().Where(p =>
 						p.Surface == emp.PrimaryRace.NativeSurface &&
 						p.Atmosphere == emp.PrimaryRace.NativeAtmosphere &&
-						p.Size == HomeworldSize &&
-						!p.Size.IsConstructed).PickRandom(dice);
+						p.Size == HomeworldSize)
+						.PickRandom(dice);
 			if (hw == null)
 				throw new Exception("No planets found in SectType.txt with surface " + emp.PrimaryRace.NativeSurface + ", atmosphere " + emp.PrimaryRace.NativeAtmosphere + ", and size " + HomeworldSize + ". Such a planet is required for creating the " + emp + " homeworld.");
 			hw = hw.Instantiate();


### PR DESCRIPTION
Only allow homeworlds to be planet sizes that can be any surface or atmosphere, to prevent errors placing empires. Allow homeworlds to be constructed worlds such as sphereworlds. Closes #220.