### PR TITLE
#353 - Fix empire color not rendering in empire setup

### DIFF
--- a/FrEee.UI.Blazor/Views/ImageDisplay.razor
+++ b/FrEee.UI.Blazor/Views/ImageDisplay.razor
@@ -5,4 +5,4 @@
 <img
 	src="@VM.ImageSource"
 	@onclick="VM.OnClick"
-	style="overflow: hidden; aspect-ratio: @(VM.AspectRatio); width: 100%; max-width: 100%; max-height: 100%" />
+	style="overflow: hidden; aspect-ratio: @(VM.AspectRatio); width: 100%; max-width: 100%; max-height: 100%; background-color: #@(VM.BackgroundColor.ToRgba())" />

--- a/FrEee.UI.Blazor/Views/ImageDisplayViewModel.cs
+++ b/FrEee.UI.Blazor/Views/ImageDisplayViewModel.cs
@@ -27,6 +27,8 @@ namespace FrEee.UI.Blazor.Views
 			}
 		}
 
+		public Color BackgroundColor { get; set; }
+
 		public double AspectRatio =>
 			Image == null ? 1 : ((double)Image.Width / (double)Image.Height);
 

--- a/FrEee.UI.Blazor/WebExtensions.cs
+++ b/FrEee.UI.Blazor/WebExtensions.cs
@@ -6,7 +6,7 @@ namespace FrEee.UI.Blazor
 	{
 		public static string ToRgba(this Color color)
 		{
-			var argb = color.ToArgb().ToString("x");
+			var argb = color.ToArgb().ToString("x8");
 			return argb.Substring(2) + argb.Substring(0, 2);
 		}
 	}

--- a/FrEee.UI.WinForms/Controls/Blazor/GamePictureBox.cs
+++ b/FrEee.UI.WinForms/Controls/Blazor/GamePictureBox.cs
@@ -62,4 +62,14 @@ public partial class GamePictureBox : BlazorControl, ISupportInitialize
 
 	[Obsolete]
 	public PictureBoxSizeMode SizeMode { get; set; }
+
+	public override Color BackColor
+	{
+		get => base.BackColor;
+		set
+		{
+			base.BackColor = value;
+			VM.BackgroundColor = value;
+		}
+	}
 }


### PR DESCRIPTION
And in general, ImageDisplay Blazor controls not being able to set a background color