### PR TITLE
#489 - add unit test for construction items being built sequentially

### DIFF
--- a/FrEee.Core.Domain/Objects/Civilization/Orders/ConstructionOrder.cs
+++ b/FrEee.Core.Domain/Objects/Civilization/Orders/ConstructionOrder.cs
@@ -174,7 +174,7 @@ public class ConstructionOrder<T, TTemplate> : IConstructionOrder
             // apply build rate
             var costLeft = Item.Cost - Item.ConstructionProgress;
             var spending = ResourceQuantity.Min(costLeft, queue.UnspentRate);
-            if (!(spending <= queue.Owner.StoredResources))
+            if (spending > queue.Owner.StoredResources)
             {
                 spending = ResourceQuantity.Min(spending, queue.Owner.StoredResources);
                 if (spending.IsEmpty)

--- a/FrEee.Core.Domain/Objects/GameState/Game.cs
+++ b/FrEee.Core.Domain/Objects/GameState/Game.cs
@@ -145,7 +145,7 @@ public class Game
 		get => modPath;
 		set
 		{
-			new ModLoader().Load(value);
+			new ModLoader().Load(value, includeGuiPlugins: Empire.Current != null);
 			modPath = value;
 		}
 	}

--- a/FrEee.Core.Domain/Utility/Services.cs
+++ b/FrEee.Core.Domain/Utility/Services.cs
@@ -174,7 +174,7 @@ public static class Services
 	/// <summary>
 	/// Verifies that all standard extension points have plugins loaded.
 	/// </summary>
-	public static void VerifyAll()
+	public static void VerifyAll(bool includeGuiPlugins)
 	{
 		Verify(TurnProcessor);
 		Verify(Battles);
@@ -182,7 +182,10 @@ public static class Services
 		Verify(Designs);
 		Verify(Vehicles);
 		Verify(ConstructionQueues);
-		Verify(Gui);
+		if (includeGuiPlugins)
+		{
+			Verify(Gui);
+		}
 		Verify(DesignLibrary);
 		Commands.VerifyAll();
 		Persistence.VerifyAll();

--- a/FrEee.Plugins.Default.Processes/Construction/ConstructionQueue.cs
+++ b/FrEee.Plugins.Default.Processes/Construction/ConstructionQueue.cs
@@ -394,7 +394,6 @@ public class ConstructionQueue : IConstructionQueue
 							{
 								p.Colony.TriggerHappinessChange(hm => hm.FacilityConstructed);
 							}
-
 						}
 					}
 				}

--- a/FrEee.Tests/FrEee.Tests.csproj
+++ b/FrEee.Tests/FrEee.Tests.csproj
@@ -30,4 +30,7 @@
 		<EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
 		<RootNamespace>FrEee</RootNamespace>
 	</PropertyGroup>
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+	  <Exec Command="post-build.bat $(SolutionDir) $(TargetDir)" />
+	</Target>
 </Project>

--- a/FrEee.Tests/Modding/FormulaTest.cs
+++ b/FrEee.Tests/Modding/FormulaTest.cs
@@ -70,7 +70,7 @@ public class FormulaTest
 	{
 		var gal = new Game();
 		Empire emp = new Empire();
-		Mod.Current = new ModLoader().Load("DynamicFormulaWithParameters");
+		Mod.Current = new ModLoader().Load("DynamicFormulaWithParameters", includeGuiPlugins: false);
 		var ct = Mod.Current.ComponentTemplates.First();
 		Assert.AreEqual(1, ct.WeaponInfo.GetDamage(new Shot(null, new Component(null, new MountedComponentTemplate(null, ct, null)), null, 1)));
 	}

--- a/FrEee.Tests/Modding/Loaders/ComponentLoaderTest.cs
+++ b/FrEee.Tests/Modding/Loaders/ComponentLoaderTest.cs
@@ -11,7 +11,7 @@ public class ComponentLoaderTest
 	[OneTimeSetUp]
 	public static void ClassInit()
 	{
-		new ModLoader().Load("ComponentLoaderTest");
+		new ModLoader().Load("ComponentLoaderTest", includeGuiPlugins: false);
 	}
 
 	/// <summary>

--- a/FrEee.Tests/Modding/Loaders/LoaderTest.cs
+++ b/FrEee.Tests/Modding/Loaders/LoaderTest.cs
@@ -10,9 +10,9 @@ public class LoaderTest
 	[Test]
 	public void LoadIncludeModWithoutErrors()
 	{
-		var mod = new ModLoader().Load("Include Mod");
+		var mod = new ModLoader().Load("Include Mod", includeGuiPlugins: false);
 		Assert.AreEqual(0, Mod.Errors.Count);
-		var mod2 = new ModLoader().Load("ComponentLoaderTest", false);
+		var mod2 = new ModLoader().Load("ComponentLoaderTest", false, includeGuiPlugins: false);
 		Assert.AreEqual(mod2.ComponentTemplates.Count, mod.ComponentTemplates.Count);
 	}
 

--- a/FrEee.Tests/Modding/StockMod.cs
+++ b/FrEee.Tests/Modding/StockMod.cs
@@ -12,7 +12,7 @@ public static class StockMod
 		get
 		{
 			if (instance == null)
-				instance = new ModLoader().Load(null);
+				instance = new ModLoader().Load(null, includeGuiPlugins: false);
 			return instance;
 		}
 	}

--- a/FrEee.Tests/Objects/Technology/TechnologyTest.cs
+++ b/FrEee.Tests/Objects/Technology/TechnologyTest.cs
@@ -26,7 +26,7 @@ public class TechnologyTest
 	{
 		PluginLibrary.Instance.LoadDefaultPlugins();
 		processor = Services.TurnProcessor;
-		new ModLoader().Load(null);
+		new ModLoader().Load(null, includeGuiPlugins: false);
 	}
 
 	/// <summary>

--- a/FrEee.Tests/Objects/Technology/WeaponInfoTest.cs
+++ b/FrEee.Tests/Objects/Technology/WeaponInfoTest.cs
@@ -19,7 +19,7 @@ public class WeaponInfoTest
 	[OneTimeSetUp]
 	public static void ClassInit()
 	{
-		mod = new ModLoader().Load("WeaponInfoTest");
+		mod = new ModLoader().Load("WeaponInfoTest", includeGuiPlugins: false);
 	}
 
 	/// <summary>

--- a/FrEee.Tests/Processes/Construction/ConstructionQueueTest.cs
+++ b/FrEee.Tests/Processes/Construction/ConstructionQueueTest.cs
@@ -41,8 +41,8 @@ public class ConstructionQueueTest
 	{
 		// TODO: mock construction queue rate calculations so we don't need a race, population, etc...
 		template = mod.FacilityTemplates.FindByName("Mineral Miner Facility I");
-		order1 = new ConstructionOrder<Facility, FacilityTemplate> { Template = template, Item = new Facility(template) };
-		order2 = new ConstructionOrder<Facility, FacilityTemplate> { Template = template, Item = new Facility(template) };
+		order1 = new ConstructionOrder<Facility, FacilityTemplate> { Template = template };
+		order2 = new ConstructionOrder<Facility, FacilityTemplate> { Template = template };
 		empire = TestUtilities.CreateEmpire();
 		empire.StoredResources += 10000 * Resource.Minerals;
 		empire.ResearchedTechnologies.Add(mod.Technologies.FindByName("Minerals Extraction"), 1);

--- a/FrEee.Tests/Processes/Construction/ConstructionQueueTest.cs
+++ b/FrEee.Tests/Processes/Construction/ConstructionQueueTest.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq;
+using FrEee.Extensions;
+using FrEee.Modding;
+using FrEee.Modding.Abilities;
+using FrEee.Modding.Loaders;
+using FrEee.Modding.Templates;
+using FrEee.Objects.Civilization;
+using FrEee.Objects.Civilization.Orders;
+using FrEee.Objects.GameState;
+using FrEee.Objects.Space;
+using FrEee.Objects.Technology;
+using FrEee.Plugins.Default.Processes.Construction;
+using FrEee.Utility;
+using FrEee.Vehicles;
+using FrEee.Vehicles.Types;
+using NUnit.Framework;
+
+namespace FrEee.Processes.Construction;
+
+public class ConstructionQueueTest
+{
+    private static Mod mod;
+    private FacilityTemplate template;
+    private Empire empire;
+    private Planet planet;
+    private ConstructionQueue queue;
+    private ConstructionOrder<Facility, FacilityTemplate> order1;
+	private ConstructionOrder<Facility, FacilityTemplate> order2;
+
+	[OneTimeSetUp]
+    public static void ClassInit()
+    {
+        TestUtilities.Initialize();
+        mod = Mod.Current;
+    }
+
+    [SetUp]
+    public void Init()
+    {
+        template = mod.FacilityTemplates.FindByName("Mineral Miner Facility I");
+        order1 = new ConstructionOrder<Facility, FacilityTemplate> { Template = template, Item = new Facility(template) };
+		order2 = new ConstructionOrder<Facility, FacilityTemplate> { Template = template, Item = new Facility(template) };
+		empire = TestUtilities.CreateEmpire();
+		planet = new();
+        planet.Owner = empire;
+        planet.Abilities.Add(new(planet, AbilityRule.Find("Space Yard"), null, "1", 1000));
+        queue = new(planet);
+		queue.Orders.Add(order1);
+		queue.Orders.Add(order2);
+	}
+
+    /// <summary>
+    /// Verifies that only one item is built at a time in a construction queue.
+    /// </summary>
+    [Test]
+    public void OneItemAtATime()
+    {
+        queue.ExecuteOrders();
+        Assert.AreEqual(1000, order1.Item.ConstructionProgress[Resource.Minerals]);
+		Assert.AreEqual(0, order1.Item.ConstructionProgress[Resource.Minerals]);
+	}
+}

--- a/FrEee.Tests/Processes/Construction/ConstructionQueueTest.cs
+++ b/FrEee.Tests/Processes/Construction/ConstructionQueueTest.cs
@@ -68,6 +68,6 @@ public class ConstructionQueueTest
 	{
 		queue.ExecuteOrders();
 		Assert.AreEqual(1000, order1.Item.ConstructionProgress[Resource.Minerals]);
-		Assert.AreEqual(0, order1.Item.ConstructionProgress[Resource.Minerals]);
+		Assert.AreEqual(0, order2.Item.ConstructionProgress[Resource.Minerals]);
 	}
 }

--- a/FrEee.Tests/Processes/Construction/ConstructionQueueTest.cs
+++ b/FrEee.Tests/Processes/Construction/ConstructionQueueTest.cs
@@ -20,44 +20,54 @@ namespace FrEee.Processes.Construction;
 
 public class ConstructionQueueTest
 {
-    private static Mod mod;
-    private FacilityTemplate template;
-    private Empire empire;
-    private Planet planet;
-    private ConstructionQueue queue;
-    private ConstructionOrder<Facility, FacilityTemplate> order1;
+	private static Mod mod;
+	private FacilityTemplate template;
+	private Empire empire;
+	private Race race;
+	private Planet planet;
+	private ConstructionQueue queue;
+	private ConstructionOrder<Facility, FacilityTemplate> order1;
 	private ConstructionOrder<Facility, FacilityTemplate> order2;
 
 	[OneTimeSetUp]
-    public static void ClassInit()
-    {
-        TestUtilities.Initialize();
-        mod = Mod.Current;
-    }
+	public static void ClassInit()
+	{
+		TestUtilities.Initialize();
+		mod = Mod.Current;
+	}
 
-    [SetUp]
-    public void Init()
-    {
-        template = mod.FacilityTemplates.FindByName("Mineral Miner Facility I");
-        order1 = new ConstructionOrder<Facility, FacilityTemplate> { Template = template, Item = new Facility(template) };
+	[SetUp]
+	public void Init()
+	{
+		// TODO: mock construction queue rate calculations so we don't need a race, population, etc...
+		template = mod.FacilityTemplates.FindByName("Mineral Miner Facility I");
+		order1 = new ConstructionOrder<Facility, FacilityTemplate> { Template = template, Item = new Facility(template) };
 		order2 = new ConstructionOrder<Facility, FacilityTemplate> { Template = template, Item = new Facility(template) };
 		empire = TestUtilities.CreateEmpire();
-		planet = new();
-        planet.Owner = empire;
-        planet.Abilities.Add(new(planet, AbilityRule.Find("Space Yard"), null, "1", 1000));
-        queue = new(planet);
+		empire.StoredResources += 10000 * Resource.Minerals;
+		empire.ResearchedTechnologies.Add(mod.Technologies.FindByName("Minerals Extraction"), 1);
+		race = new();
+		race.Aptitudes.Add(Aptitude.Construction.Name, 100);
+		planet = new()
+		{
+			Owner = empire,
+			Size = new() { MaxPopulation = 1_000_000, MaxPopulationDomed = 1_000_000 }
+		};
+		planet.AddPopulation(race, 1_000_000);
+		planet.Abilities.Add(new(planet, AbilityRule.Find("Space Yard"), null, "1", 1000));
+		queue = new(planet);
 		queue.Orders.Add(order1);
 		queue.Orders.Add(order2);
 	}
 
-    /// <summary>
-    /// Verifies that only one item is built at a time in a construction queue.
-    /// </summary>
-    [Test]
-    public void OneItemAtATime()
-    {
-        queue.ExecuteOrders();
-        Assert.AreEqual(1000, order1.Item.ConstructionProgress[Resource.Minerals]);
+	/// <summary>
+	/// Verifies that only one item is built at a time in a construction queue.
+	/// </summary>
+	[Test]
+	public void OneItemAtATime()
+	{
+		queue.ExecuteOrders();
+		Assert.AreEqual(1000, order1.Item.ConstructionProgress[Resource.Minerals]);
 		Assert.AreEqual(0, order1.Item.ConstructionProgress[Resource.Minerals]);
 	}
 }

--- a/FrEee.Tests/Setup/GameSetupTest.cs
+++ b/FrEee.Tests/Setup/GameSetupTest.cs
@@ -14,7 +14,7 @@ public class GameSetupTest
 	public void Quickstart()
 	{
 		var setup = Services.Persistence.GameSetup.LoadFromFile(@"..\..\..\..\FrEee\GameSetups\quickstart.gsu");
-		Mod.Current = new ModLoader().Load(null);
+		Mod.Current = new ModLoader().Load(null, includeGuiPlugins: false);
 		Game.Initialize(setup, null);
 	}
 }

--- a/FrEee.Tests/TestUtilities.cs
+++ b/FrEee.Tests/TestUtilities.cs
@@ -17,7 +17,7 @@ public static class TestUtilities
 	{
 		PluginLibrary.Instance.LoadDefaultPlugins();
 		Game game = new();
-		Mod.Current = new ModLoader().Load(modPath);
+		Mod.Current = new ModLoader().Load(modPath, includeGuiPlugins: false);
 		game.Galaxy = new();
 		game.Setup = new();
 		return game;

--- a/FrEee.Tests/Utility/SerializerTest.cs
+++ b/FrEee.Tests/Utility/SerializerTest.cs
@@ -154,7 +154,7 @@ public class SerializerTest
 	[Test]
 	public void CorrectAbilities()
 	{
-		new ModLoader().Load(null);
+		new ModLoader().Load(null, includeGuiPlugins: false);
 		var ft1 = new FacilityTemplate();
 		ft1.Name = "Mineral Miner Test";
 		ft1.Abilities.Add(new Ability(ft1, Mod.Current.AbilityRules.FindByName("Resource Generation - Minerals"), null, 800));
@@ -174,7 +174,7 @@ public class SerializerTest
 	[Test]
 	public void CorrectAbilities2()
 	{
-		new ModLoader().Load(null);
+		new ModLoader().Load(null, includeGuiPlugins: false);
 		var serdata = Serializer.SerializeToString(Mod.Current);
 		Mod.Current = Serializer.DeserializeFromString<Mod>(serdata);
 		Assert.AreEqual(800, Mod.Current.FacilityTemplates.Single(x => x.Name == "Mineral Miner Facility I").GetAbilityValue("Resource Generation - Minerals").ToInt());

--- a/FrEee.Tests/post-build.bat
+++ b/FrEee.Tests/post-build.bat
@@ -1,0 +1,2 @@
+echo Copying plugins from %1 to %2
+xcopy "%1\Plugins\" "%2\Plugins\" /Y /R /I


### PR DESCRIPTION
I couldn't reproduce the bug where they got built in parallel but now we have a test. Also fixed some other tests that were broken due to misconfigured plugins.