### PR TITLE
#295 - fix crash comparing designs with null data

### DIFF
--- a/FrEee.Core.Domain/Objects/Civilization/Orders/ConstructionOrder.cs
+++ b/FrEee.Core.Domain/Objects/Civilization/Orders/ConstructionOrder.cs
@@ -117,8 +117,10 @@ public class ConstructionOrder<T, TTemplate> : IConstructionOrder
 
     private GameReference<Empire> owner { get; set; }
     private IReference<TTemplate> template { get; set; }
+	public bool IsMemory { get; set; }
+	public double Timestamp { get; set; }
 
-    public bool CheckCompletion(IOrderable q)
+	public bool CheckCompletion(IOrderable q)
     {
         var queue = (IConstructionQueue)q;
         isComplete = Item.ConstructionProgress >= Item.Cost || GetErrors(queue).Any();
@@ -133,7 +135,7 @@ public class ConstructionOrder<T, TTemplate> : IConstructionOrder
     public Visibility CheckVisibility(Empire emp)
     {
         if (emp == Owner)
-            return Visibility.Visible;
+            return Visibility.Owned;
         return Visibility.Unknown;
     }
 
@@ -223,4 +225,18 @@ public class ConstructionOrder<T, TTemplate> : IConstructionOrder
     {
         Item = default;
     }
+
+	public bool IsObsoleteMemory(Empire emp)
+	{
+        return false;
+	}
+
+	public void Redact(Empire emp)
+	{
+		if (CheckVisibility(emp) < Visibility.Owned)
+        {
+            // TODO: intel projects to see alien orders
+            Dispose();
+        }
+	}
 }

--- a/FrEee.Core.Domain/Objects/Civilization/Orders/UpgradeFacilityOrder.cs
+++ b/FrEee.Core.Domain/Objects/Civilization/Orders/UpgradeFacilityOrder.cs
@@ -106,7 +106,7 @@ public class UpgradeFacilityOrder : IConstructionOrder
     public Visibility CheckVisibility(Empire emp)
     {
         if (emp == Owner)
-            return Visibility.Visible;
+            return Visibility.Owned;
         return Visibility.Unknown;
     }
 
@@ -197,4 +197,22 @@ public class UpgradeFacilityOrder : IConstructionOrder
     {
         NewFacility = null;
     }
+
+    public bool IsMemory { get; set; }
+
+    public double Timestamp { get; set; }
+
+	public bool IsObsoleteMemory(Empire emp)
+	{
+		return false;
+	}
+
+	public void Redact(Empire emp)
+	{
+		if (CheckVisibility(emp) < Visibility.Owned)
+		{
+			// TODO: intel projects to see alien orders
+			Dispose();
+		}
+	}
 }

--- a/FrEee.Core.Domain/Processes/Construction/IConstructionOrder.cs
+++ b/FrEee.Core.Domain/Processes/Construction/IConstructionOrder.cs
@@ -3,7 +3,8 @@ using FrEee.Objects.GameState;
 using FrEee.Utility;
 namespace FrEee.Processes.Construction;
 
-public interface IConstructionOrder : IOrder, INamed
+// TODO: IOrder itself should implement IFoggable
+public interface IConstructionOrder : IOrder, INamed, IFoggable
 {
 	/// <summary>
 	/// The cost of the construction.

--- a/FrEee.Plugins.Default.Processes/Construction/ConstructionQueue.cs
+++ b/FrEee.Plugins.Default.Processes/Construction/ConstructionQueue.cs
@@ -320,6 +320,7 @@ public class ConstructionQueue : IConstructionQueue
 		}
 
 		Game.Current.UnassignID(this);
+		Orders.DisposeAll();
 		Orders.Clear();
 		IsDisposed = true;
 	}

--- a/FrEee.Plugins.Default.Vehicles/Design.cs
+++ b/FrEee.Plugins.Default.Vehicles/Design.cs
@@ -646,6 +646,7 @@ public class Design<T> : IDesign<T>, ITemplate<T> where T : IVehicle
 		Game.Current.UnassignID(this);
 		foreach (var emp in Game.Current.Empires.Where(e => e != null))
 			emp.KnownDesigns.Remove(this);
+		IsDisposed = true;
 	}
 
 	public override bool Equals(object? obj)

--- a/FrEee.Plugins.Default.Vehicles/Design.cs
+++ b/FrEee.Plugins.Default.Vehicles/Design.cs
@@ -655,6 +655,8 @@ public class Design<T> : IDesign<T>, ITemplate<T> where T : IVehicle
 		{
 			if (d.BaseName != BaseName)
 				return false;
+			if (d.Hull is null)
+				return false; // HACK: design is leaking from another player's game state
 			if (d.Hull.ModID != Hull.ModID)
 				return false;
 			if (d.Components.Count != Components.Count)


### PR DESCRIPTION
Workaround for this crash. Also make construction orders foggable to prevent designs from leaking in the first place but that didn't seem to work.