### PR TITLE
#496 - Fix crash when loading design library

### DIFF
--- a/FrEee.Plugins.Default.Vehicles/Design.cs
+++ b/FrEee.Plugins.Default.Vehicles/Design.cs
@@ -119,8 +119,8 @@ public class Design<T> : IDesign<T>, ITemplate<T> where T : IVehicle
 		get { return Hull; }
 		set
 		{
-			if (value is IHull<T> h)
-				Hull = h;
+			if (value.VehicleType == VehicleType)
+				Hull = value;
 			else
 				throw new Exception("Can't use a " + value.VehicleType + " hull on a " + VehicleType + " design.");
 		}


### PR DESCRIPTION
When is an IHull<Ship> not an IHull<Ship>? When the Ship type is defined in a plugin! Fortunately we have a VehicleTypes enum...