### PR TITLE
#485 - Fix hulls, components, and mounts being listed in reverse order in the GUI

### DIFF
--- a/FrEee.Core.Domain/Modding/Mod.cs
+++ b/FrEee.Core.Domain/Modding/Mod.cs
@@ -160,7 +160,7 @@ public class Mod : IDisposable
 	/// </summary>
 	public ICollection<Mount> Mounts { get; private set; }
 
-	private ConcurrentBag<IModObject> objects = [ FacilityTemplate.Unknown ];
+	private ConcurrentQueue<IModObject> objects = new([ FacilityTemplate.Unknown ]);
 
 	/// <summary>
 	/// All mod objects.
@@ -307,7 +307,7 @@ public class Mod : IDisposable
 			}
 
 			if (!objects.Contains(mo))
-				objects.Add(mo);
+				objects.Enqueue(mo);
 		}
 	}
 


### PR DESCRIPTION
Use a ConcurrentQueue rather than a ConcurrentBag for storing mod objects to preserve their order from the data files