### PR TITLE
#514 - improve performance perhaps further by filtering game objects better when searching

### DIFF
--- a/FrEee.Core.Domain/Modding/Mod.cs
+++ b/FrEee.Core.Domain/Modding/Mod.cs
@@ -392,75 +392,75 @@ public class Mod : IDisposable
 			// try to filter mod objects quickly
 			if (typeof(T).IsAssignableTo(typeof(AbilityRule)))
 			{
-				list = Mod.Current.AbilityRules;
+				list = AbilityRules;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(Trait)))
 			{
-				list = Mod.Current.Traits;
+				list = Traits;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(Technology)))
 			{
-				list = Mod.Current.Technologies;
+				list = Technologies;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(FacilityTemplate)))
 			{
-				list = Mod.Current.FacilityTemplates;
+				list = FacilityTemplates;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(IHull)))
 			{
-				list = Mod.Current.Hulls;
+				list = Hulls;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(DamageType)))
 			{
-				list = Mod.Current.DamageTypes;
+				list = DamageTypes;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(ComponentTemplate)))
 			{
-				list = Mod.Current.ComponentTemplates;
+				list = ComponentTemplates;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(Mount)))
 			{
-				list = Mod.Current.Mounts;
+				list = Mounts;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(StellarObjectSize)))
 			{
-				list = Mod.Current.StellarObjectSizes;
+				list = StellarObjectSizes;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(StarSystemTemplate)))
 			{
-				list = Mod.Current.StarSystemTemplates;
+				list = StarSystemTemplates;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(RandomAbilityTemplate)))
 			{
-				list = Mod.Current.StellarAbilityTemplates;
+				list = StellarAbilityTemplates;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(GalaxyTemplate)))
 			{
-				list = Mod.Current.GalaxyTemplates;
+				list = GalaxyTemplates;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(StellarObject)))
 			{
-				list = Mod.Current.StellarObjectTemplates;
+				list = StellarObjectTemplates;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(HappinessModel)))
 			{
-				list = Mod.Current.HappinessModels;
+				list = HappinessModels;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(Culture)))
 			{
-				list = Mod.Current.Cultures;
+				list = Cultures;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(AI<Empire, Game>)))
 			{
-				list = Mod.Current.EmpireAIs;
+				list = EmpireAIs;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(EventType)))
 			{
-				list = Mod.Current.EventTypes;
+				list = EventTypes;
 			}
 			else if (typeof(T).IsAssignableTo(typeof(EventTemplate)))
 			{
-				list = Mod.Current.EventTemplates;
+				list = EventTemplates;
 			}
 
 			// find the mod object searched for

--- a/FrEee.Core.Domain/Objects/GameState/Game.cs
+++ b/FrEee.Core.Domain/Objects/GameState/Game.cs
@@ -700,13 +700,33 @@ public class Game
 	/// Finds referrable objects in the game.
 	/// </summary>
 	/// <typeparam name="T"></typeparam>
-	/// <param name="condition"></param>
 	/// <returns></returns>
-	public IEnumerable<T> Find<T>(Func<T, bool>? condition = null) where T : IReferrable
+	public T? Find<T>(long id)
+		where T : IReferrable
 	{
-		if (condition is null)
-			condition = t => true;
-		return Referrables.OfType<T>().Where(r => condition(r));
+		// fall back to scanning all referrables
+		IEnumerable<IReferrable> list = Referrables;
+
+		// try to filter based on type
+		if (typeof(T).IsAssignableTo(typeof(Empire)))
+		{
+			list = Empires.ExceptNull();
+		}
+		else if (typeof(T).IsAssignableTo(typeof(StarSystem)))
+		{
+			list = Galaxy?.StarSystems ?? [];
+		}
+		else if (typeof(T).IsAssignableTo(typeof(ISpaceObject)))
+		{
+			list = (IEnumerable<IReferrable>)(Galaxy?.FindSpaceObjects<T>() ?? []);
+		}
+		else if (typeof(T).IsAssignableTo(typeof(IDesign)))
+		{
+			list = Designs;
+		}
+
+		// perform the search
+		return list.OfType<T>().FirstOrDefault(q => q.ID == id);
 	}
 
 	public string GetEmpireCommandsSavePath(Empire emp)

--- a/FrEee.Core.Domain/Objects/GameState/GameReference.cs
+++ b/FrEee.Core.Domain/Objects/GameState/GameReference.cs
@@ -46,25 +46,7 @@ public record GameReference<T>(long ID)
 	/// Resolves the reference.
 	/// </summary>
 	/// <returns></returns>
-	public T Value
-	{
-		get
-		{
-			if (typeof(T).IsAssignableTo(typeof(Empire)))
-			{
-				return (T)(object)Game.Current.Empires.ExceptNull().SingleOrDefault(q => q.ID == ID);
-			}
-			if (typeof(T).IsAssignableTo(typeof(IDesign)))
-			{
-				return (T)Game.Current.Designs.SingleOrDefault(q => q.ID == ID);
-			}
-			else
-			{
-				// general referrables with no specific lookup
-				return (T)Game.Current.GetReferrable(ID);
-			}
-		}
-	}
+	public T Value => Game.Current.Find<T>(ID);
 
 	public static implicit operator GameReference<T>?(T t)
 	{


### PR DESCRIPTION
Also fix Mod.Current always being used for filtering objects in a mod (see #517) , rather than the actual mod instance.