### PR TITLE
#475 - Add some readme files for a couple of asset folders

### DIFF
--- a/FrEee.Assets/Empires/readme.txt
+++ b/FrEee.Assets/Empires/readme.txt
@@ -1,0 +1,4 @@
+The Empires folder contains any saved empire files that players create when setting up games.
+These files store information about the player's empire, including its name, colors, racial traits, and other settings.
+When a player creates a new empire in the game, they can customize various aspects of their empire and then save it to this folder. The saved empire files can be loaded later when starting a new game, allowing players to quickly select and reuse their preferred empire without having to reconfigure its settings each time they play.
+These empire files also need to be sent to the game host in multiplayer games so that the host can set up the game with all players' empires included.

--- a/FrEee.Assets/FrEee.Assets.csproj
+++ b/FrEee.Assets/FrEee.Assets.csproj
@@ -46,6 +46,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Empires\" />
+    <Folder Include="Savegame\" />
+  </ItemGroup>
 	<PropertyGroup>
 		<EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
 	</PropertyGroup>

--- a/FrEee.Assets/GameSetups/readme.txt
+++ b/FrEee.Assets/GameSetups/readme.txt
@@ -1,0 +1,4 @@
+The GameSetups folder contains predefined game setup configurations for FrEee.
+By default, the game includes one game setup file, Quickstart.gsu, which is used for quick single-player games.
+Players can create and save their own custom game setups in this folder, allowing them to quickly start new games with their preferred settings, or share setups of games they are hosting with their players.
+To create a new game setup, players can configure the desired game options in the game's setup menu and then save the configuration to this folder instead of actually starting the game.

--- a/FrEee.Assets/Savegame/readme.txt
+++ b/FrEee.Assets/Savegame/readme.txt
@@ -1,0 +1,5 @@
+The Savegame folder contains saved game files and player command files for FrEee.
+There are three types of files in this folder:
+- Master game files (e.g. MyGame_1.gam) - these are the main save files for a game, containing the full state of the game at a particular turn. The 1 in this example indicates the turn number.
+- Player game files (e.g. MyGame_1_0001.gam) - these files contain the state of the game as seen by a particular player, including their own empire's information and anything else visible in the fog of war. The 1 in this example indicates the turn number, and 0001 is the player number.
+- Player command files (e.g. MyGame_1_0001.plr) - these files contain the commands issued by a particular player during a turn, including any orders given to their vehicles, colonies, or construction queues. The 1 in this example indicates the turn number, and 0001 is the player number.


### PR DESCRIPTION
This should make sure that those folders actually exist when booting up the game for the first time, and also provide documentation for players.

The GitHub Copilot AI came in handy when writing these readmes, even if it did want to make up a silly subtitle for the game! 🙂