### PR TITLE
#500 - Fix research progress bar always showing a minimum of 3 turns to completion

### DIFF
--- a/FrEee.UI.Blazor/Views/ProgressBar.razor
+++ b/FrEee.UI.Blazor/Views/ProgressBar.razor
@@ -4,10 +4,10 @@
 
 <div @onclick="VM.OnClick" style="display: grid; height: 36px; overflow: hidden">
 	<div class="fill" style="display: flex; flex-direction: row; grid-area: 1/1/1/1;">
-		<div style="width: @(100 * VM.Value / Math.Max(1, VM.Maximum))%; height: 100%; padding: 0; background-color: #@VM.BarColor.ToRgba()" />
-		<div style="width: @(100 * VM.Increment / Math.Max(1, VM.Maximum))%; height: 100%; padding: 0; background-color: #@VM.IncrementColor1.ToRgba()" />
-		<div style="width: @(100 * VM.Increment / Math.Max(1, VM.Maximum))%; height: 100%; padding: 0; background-color: #@VM.IncrementColor2.ToRgba()" />
-		<div style="width: @(100 * VM.Increment / Math.Max(1, VM.Maximum))%; height: 100%; padding: 0; background-color: #@VM.IncrementColor3.ToRgba()" />
+		<div style="width: @VM.GetProgressPercentage(0)%; height: 100%; padding: 0; background-color: #@VM.BarColor.ToRgba()" />
+		<div style="width: @VM.GetProgressPercentage(1)%; height: 100%; padding: 0; background-color: #@VM.IncrementColor1.ToRgba()" />
+		<div style="width: @VM.GetProgressPercentage(2)%; height: 100%; padding: 0; background-color: #@VM.IncrementColor2.ToRgba()" />
+		<div style="width: @VM.GetProgressPercentage(3)%; height: 100%; padding: 0; background-color: #@VM.IncrementColor3.ToRgba()" />
 	</div>
 	<div class="fill overlay" style="display: flex; flex-direction: row; justify-content: space-between; grid-area: 1/1/1/1; margin: 5px">
 		<span style="width: 33%; text-align: left">

--- a/FrEee.UI.Blazor/Views/ProgressBarViewModel.cs
+++ b/FrEee.UI.Blazor/Views/ProgressBarViewModel.cs
@@ -64,5 +64,40 @@ namespace FrEee.UI.Blazor.Views
 		}
 
 		public ProgressDisplayType ProgressDisplayType { get; set; } = ProgressDisplayType.Percentage;
+
+		/// <summary>
+		/// Calculates the per-turn progress percentage to show on the bar after a certain number of turns.
+		/// </summary>
+		/// <param name="turnsAhead">The number of turns to look ahead.</param>
+		/// <returns>
+		/// The progress percentage achieved on the specified turn (not incremental).
+		/// Capped so that the total progress never exceeds 100%.
+		/// </returns>
+		public double GetProgressPercentage(int turnsAhead)
+		{
+			// calculate starting point for current turn
+			var currentValue = Progress.Value;
+			var totalValue = currentValue;
+
+			// calculate progress for future turns
+			for (var turn = 1; turn <= turnsAhead; turn++)
+			{
+				// apply incremental progress
+				currentValue = Increment;
+				totalValue += currentValue;
+
+				// cap at maximum
+				if (totalValue > Maximum)
+				{
+					currentValue -= totalValue - Maximum;
+					totalValue = Maximum;
+				}
+			}
+
+			// calculate and return percentage
+			var max = Maximum > 0 ? Maximum : 1; // avoid divide by zero
+			var currentPercentage = currentValue * 100d / max; // allow fractional percentages to prevent rounding error
+			return currentPercentage;
+		}
 	}
 }


### PR DESCRIPTION
Graphically at least - the text value was correct, but the bar itself was wrong