### PR TITLE
#487 - Handle invalid drawing context exceptions on galaxy map when rapidly refreshing

### DIFF
--- a/FrEee.UI.Blazor/FrEee.UI.Blazor.csproj
+++ b/FrEee.UI.Blazor/FrEee.UI.Blazor.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Excubo.Blazor.Canvas" Version="3.2.64" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+    <PackageReference Include="Excubo.Blazor.Canvas" Version="3.2.91" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.9" />
     <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
   </ItemGroup>
 

--- a/FrEee.UI.Blazor/Views/GalaxyMap.razor.cs
+++ b/FrEee.UI.Blazor/Views/GalaxyMap.razor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices.JavaScript;
 using System.Text;
 using System.Threading.Tasks;
 using Excubo.Blazor.Canvas;
@@ -22,22 +23,31 @@ public partial class GalaxyMap
 
 		await using (var ctx = await helper_canvas.GetContext2DAsync())
 		{
-			await ctx.ClearRectAsync(0, 0, VM.Width, VM.Height);
-			await ctx.SetTransformAsync(size, 0, 0, size, xoffset * size, yoffset * size);
-			await ctx.RestoreAsync();
-			await ctx.SaveAsync();
-			await ctx.StrokeStyleAsync("white");
-			await ctx.LineWidthAsync(0.1);
-			foreach (var connections in VM.WarpGraph.Connections)
+			try
 			{
-				var src = connections.Key;
-				foreach (var dest in connections.Value)
+				await ctx.ClearRectAsync(0, 0, VM.Width, VM.Height);
+				await ctx.SetTransformAsync(size, 0, 0, size, xoffset * size, yoffset * size);
+				await ctx.RestoreAsync();
+				await ctx.SaveAsync();
+				await ctx.StrokeStyleAsync("white");
+				await ctx.LineWidthAsync(0.1);
+				foreach (var connections in VM.WarpGraph.Connections)
 				{
-					// TODO: display one way warps differently (arrows, incomplete lines, gradients?)
-					await ctx.MoveToAsync(src.Location.X + 0.5, src.Location.Y + 0.5);
-					await ctx.LineToAsync(dest.Location.X + 0.5, dest.Location.Y + 0.5);
-					await ctx.StrokeAsync();
+					var src = connections.Key;
+					foreach (var dest in connections.Value)
+					{
+						// TODO: display one way warps differently (arrows, incomplete lines, gradients?)
+						await ctx.MoveToAsync(src.Location.X + 0.5, src.Location.Y + 0.5);
+						await ctx.LineToAsync(dest.Location.X + 0.5, dest.Location.Y + 0.5);
+						await ctx.StrokeAsync();
+					}
 				}
+			}
+			catch (Exception ex)
+			{
+				// need to catch Exception, not JSException, because of Blazor exception marshalling or something
+				// do nothing, the drawing context is invalid because we have refreshed recently
+				// e.g by moving the mouse over several queues quickly
 			}
 		}
 

--- a/FrEee.UI.WinForms/FrEee.UI.WinForms.csproj
+++ b/FrEee.UI.WinForms/FrEee.UI.WinForms.csproj
@@ -9,12 +9,12 @@
 	<Import Project="../FrEee.Assets/CommonProjectProperties.xml" />
 	<ItemGroup>
 		<PackageReference Include="IronPython" Version="3.4.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="9.0.10" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="9.0.110" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
 		<PackageReference Include="NAudio" Version="2.2.1" />
 		<PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
-		<PackageReference Include="System.ComponentModel.Composition" Version="9.0.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="9.0.9" />
 		<ProjectReference Include="..\FrEee.Assets\FrEee.Assets.csproj" />
 		<ProjectReference Include="..\FrEee.Core.Domain\FrEee.Core.Domain.csproj" />
 		<ProjectReference Include="..\FrEee.Core.Utility\FrEee.Core.Utility.csproj" />


### PR DESCRIPTION
e.g. on the construction queues screen